### PR TITLE
Implement support for custom Content subdocuments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
           env: TEST_CONFIG="phpunit-integration-solr.xml" SOLR_VERSION="6.5.1"  CORES_SETUP="shared" COMPOSER_REQUIRE="ezsystems/ezpublish-kernel:~6.7.4@dev"
         - php: 7.2
           env: TEST_CONFIG="phpunit-integration-solr.xml" SOLR_VERSION="6.6.0"  CORES_SETUP="dedicated"
+        - php: 7.2
+          env: TEST_CONFIG="vendor/ezsystems/ezpublish-kernel/phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.6.0" CORES_SETUP="shared" REGRESSION="yes"
 
 branches:
     only:
@@ -30,11 +32,20 @@ branches:
 before_script:
     - phpenv config-rm xdebug.ini
     - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-    - if [ "$COMPOSER_REQUIRE" != "" ] ; then composer require --no-update $COMPOSER_REQUIRE ; fi
+    - if [ "$COMPOSER_REQUIRE" != "" ]; then
+          composer require --no-update $COMPOSER_REQUIRE;
+      fi
     - travis_retry composer update --prefer-dist --no-interaction
-    - if [ "$TEST_CONFIG" = "phpunit-integration-solr.xml" ] ; then cd ./vendor/ezsystems/ezplatform-solr-search-engine; ./bin/.travis/init_solr.sh; cd ../../..; fi
+    - if [[ $TEST_CONFIG = *"solr"* ]]; then
+          cd ./vendor/ezsystems/ezplatform-solr-search-engine;
+          ./bin/.travis/init_solr.sh;
+          cd ../../..;
+      fi
 
 script:
+    - if [ "$REGRESSION" = "yes" ]; then
+          sed -i.bak s/EzSystems\\\\EzPlatformSolrSearchEngine\\\\Tests\\\\SetupFactory\\\\LegacySetupFactory/Netgen\\\\EzPlatformSearchExtra\\\\Tests\\\\SetupFactory\\\\Solr/g $TEST_CONFIG;
+      fi
     - php vendor/bin/phpunit --bootstrap tests/bootstrap.php -c $TEST_CONFIG
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ for more details.
 
 - [`ObjectStateIdentifier`](https://github.com/netgen/ezplatform-search-extra/blob/master/lib/API/Values/Content/Query/Criterion/ObjectStateIdentifier.php) criterion
 - [`SectionIdentifier`](https://github.com/netgen/ezplatform-search-extra/blob/master/lib/API/Values/Content/Query/Criterion/SectionIdentifier.php) criterion
-- Support for custom Content subdocuments
+- Support for custom Content subdocuments (Solr search engine)
 
   Provides a way to index custom subdocuments to Content document and
   [`SubdocumentQuery`](https://github.com/netgen/ezplatform-search-extra/blob/master/lib/API/Values/Content/Query/Criterion/SubdocumentQuery.php)

--- a/README.md
+++ b/README.md
@@ -7,12 +7,21 @@
 
 ## Features
 
+Only a short list of features is provided here, see
+[documentation](https://netgen-ezplatform-search-extra.readthedocs.io)
+for more details.
+
 - [`IsFieldEmpty`](https://github.com/netgen/ezplatform-search-extra/blob/master/lib/API/Values/Content/Query/Criterion/IsFieldEmpty.php) criterion
 
   This will work only with Solr search engine and it will require initial reindexing after installation.
 
 - [`ObjectStateIdentifier`](https://github.com/netgen/ezplatform-search-extra/blob/master/lib/API/Values/Content/Query/Criterion/ObjectStateIdentifier.php) criterion
 - [`SectionIdentifier`](https://github.com/netgen/ezplatform-search-extra/blob/master/lib/API/Values/Content/Query/Criterion/SectionIdentifier.php) criterion
+- Support for custom Content subdocuments
+
+  Provides a way to index custom subdocuments to Content document and
+  [`SubdocumentQuery`](https://github.com/netgen/ezplatform-search-extra/blob/master/lib/API/Values/Content/Query/Criterion/SubdocumentQuery.php)
+  criterion, available in Content search to define grouped conditions for a custom subdocument.
 
 ## Installation
 

--- a/bundle/DependencyInjection/NetgenEzPlatformSearchExtraExtension.php
+++ b/bundle/DependencyInjection/NetgenEzPlatformSearchExtraExtension.php
@@ -32,6 +32,7 @@ class NetgenEzPlatformSearchExtraExtension extends Extension
             $loader->load('search/solr.yml');
         }
 
+        $loader->load('search/common.yml');
         $loader->load('persistence.yml');
     }
 }

--- a/bundle/NetgenEzPlatformSearchExtraBundle.php
+++ b/bundle/NetgenEzPlatformSearchExtraBundle.php
@@ -13,6 +13,7 @@ class NetgenEzPlatformSearchExtraBundle extends Bundle
     {
         parent::build($containerBuilder);
 
+        // Needs to be added first because other passes depend on it
         $containerBuilder->addCompilerPass(new Compiler\TagSubdocumentCriterionVisitorsPass());
         $containerBuilder->addCompilerPass(new Compiler\AggregateContentSubdocumentMapperPass());
         $containerBuilder->addCompilerPass(new Compiler\AggregateContentTranslationSubdocumentMapperPass());

--- a/bundle/NetgenEzPlatformSearchExtraBundle.php
+++ b/bundle/NetgenEzPlatformSearchExtraBundle.php
@@ -2,8 +2,20 @@
 
 namespace Netgen\Bundle\EzPlatformSearchExtraBundle;
 
+use Netgen\EzPlatformSearchExtra\Container\Compiler;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+
 
 class NetgenEzPlatformSearchExtraBundle extends Bundle
 {
+    public function build(ContainerBuilder $containerBuilder)
+    {
+        parent::build($containerBuilder);
+
+        $containerBuilder->addCompilerPass(new Compiler\TagSubdocumentCriterionVisitorsPass());
+        $containerBuilder->addCompilerPass(new Compiler\AggregateContentSubdocumentMapperPass());
+        $containerBuilder->addCompilerPass(new Compiler\AggregateContentTranslationSubdocumentMapperPass());
+        $containerBuilder->addCompilerPass(new Compiler\AggregateSubdocumentQueryCriterionVisitorPass());
+    }
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ extensions = ['sphinx.ext.autodoc',
 source_suffix = '.rst'
 master_doc = 'index'
 
-project = 'Netgen\'s Site API for eZ Platform'
+project = 'Netgen\'s extra bits for eZ Platform search'
 copyright = 'Netgen'
 author = 'Netgen'
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ extensions = ['sphinx.ext.autodoc',
 source_suffix = '.rst'
 master_doc = 'index'
 
-project = 'Netgen\'s extra bits for eZ Platform search'
+project = 'Netgen\'s eZ Platform Search Extra'
 copyright = 'Netgen'
 author = 'Netgen'
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+
+import sys, os
+import sphinx_rtd_theme
+
+from sphinx.highlighting import lexers
+from pygments.lexers.web import PhpLexer
+from pygments.lexers.web import HtmlLexer
+from pygments.lexers.web import JsonLexer
+
+from datetime import datetime
+
+lexers['php'] = PhpLexer(startinline=True)
+lexers['php-annotations'] = PhpLexer(startinline=True)
+lexers['html'] = HtmlLexer(startinline=True)
+lexers['json'] = JsonLexer(startinline=True)
+
+extensions = ['sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
+    'sphinx.ext.todo',
+    'sphinx.ext.coverage',
+    'sphinx.ext.imgmath',
+    'sphinx.ext.ifconfig',
+    'sensio.sphinx.configurationblock']
+
+source_suffix = '.rst'
+master_doc = 'index'
+
+project = 'Netgen\'s Site API for eZ Platform'
+copyright = 'Netgen'
+author = 'Netgen'
+
+version = ''
+release = ''
+
+exclude_patterns = ['_build']
+
+html_theme = "sphinx_rtd_theme"
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
+html_static_path = ['_static']
+templates_path = ['_templates']
+
+html_theme_options = {
+    'collapse_navigation': True,
+    'display_version': True,
+}
+
+html_context = {
+    'copyright_url': 'https://www.netgenlabs.com',
+    'current_year': datetime.utcnow().year
+}
+
+def setup(app):
+    app.add_stylesheet("css/style.css")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,12 @@
+Netgen's extra bits for eZ Platform search
+==========================================
+
+Reference
+---------
+
+.. toctree::
+:hidden:
+
+        reference/index
+
+.. include:: /reference/map.rst.inc

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,8 +5,8 @@ Reference
 ---------
 
 .. toctree::
-:hidden:
+    :hidden:
 
-        reference/index
+    reference/index
 
 .. include:: /reference/map.rst.inc

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
-Netgen's extra bits for eZ Platform search
-==========================================
+Netgen's eZ Platform Search Extra
+=================================
 
 Reference
 ---------

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,0 +1,10 @@
+Reference
+=========
+
+.. toctree::
+    :hidden:
+
+    installation_instructions
+    subdocuments
+
+.. include:: /reference/map.rst.inc

--- a/docs/reference/installation_instructions.rst
+++ b/docs/reference/installation_instructions.rst
@@ -1,0 +1,23 @@
+Installation instructions
+=========================
+
+To install Site API first add it as a dependency to your project:
+
+.. code-block:: shell
+
+    $ composer require netgen/ezplatform-site-api:^2.5
+
+Once Site API is installed, activate the bundle in ``app/AppKernel.php`` file by adding it to the
+``$bundles`` array in ``registerBundles()`` method, together with other required bundles:
+
+.. code-block:: php
+
+    public function registerBundles()
+    {
+        ...
+
+        $bundles[] = new Netgen\Bundle\EzPlatformSiteApiBundle\NetgenEzPlatformSiteApiBundle();
+        $bundles[] = new Netgen\Bundle\EzPlatformSearchExtraBundle\NetgenEzPlatformSearchExtraBundle;
+
+        return $bundles;
+    }

--- a/docs/reference/installation_instructions.rst
+++ b/docs/reference/installation_instructions.rst
@@ -1,14 +1,14 @@
 Installation instructions
 =========================
 
-To install Site API first add it as a dependency to your project:
+To install eZ Platform Search Extra first add it as a dependency to your project:
 
 .. code-block:: shell
 
-    $ composer require netgen/ezplatform-site-api:^2.5
+    $ composer require netgen/ezplatform-search-extra:^1.0
 
-Once Site API is installed, activate the bundle in ``app/AppKernel.php`` file by adding it to the
-``$bundles`` array in ``registerBundles()`` method, together with other required bundles:
+Once Search Extra is installed, activate the bundle in ``app/AppKernel.php`` file by adding it to
+the ``$bundles`` array in ``registerBundles()`` method, together with other required bundles:
 
 .. code-block:: php
 
@@ -16,7 +16,6 @@ Once Site API is installed, activate the bundle in ``app/AppKernel.php`` file by
     {
         ...
 
-        $bundles[] = new Netgen\Bundle\EzPlatformSiteApiBundle\NetgenEzPlatformSiteApiBundle();
         $bundles[] = new Netgen\Bundle\EzPlatformSearchExtraBundle\NetgenEzPlatformSearchExtraBundle;
 
         return $bundles;

--- a/docs/reference/map.rst.inc
+++ b/docs/reference/map.rst.inc
@@ -1,0 +1,2 @@
+* :doc:`/reference/installation_instructions`
+* :doc:`/reference/subdocuments`

--- a/docs/reference/subdocuments.rst
+++ b/docs/reference/subdocuments.rst
@@ -1,4 +1,198 @@
 Custom Content subdocuments
 ===========================
 
-...
+This feature provides a way to index custom subdocuments *under* a Content document and a way to
+define criteria on them using Content search.
+
+.. note::
+
+    This feature is available only for Solr search engine.
+
+.. note::
+
+    It's not possible to search for custom subdocuments directly. Instead, you can define
+    subdocument criteria as a part of Content search, using ``SubdocumentQuery`` criterion.
+
+.. note::
+
+    Relationship between Content and it's subdocuments is not assumed. These can represent children
+    under it's main Location, Content relations of a specific ContentType or something else
+    altogether.
+
+Indexing custom subdocuments
+----------------------------
+
+In order to index custom subdocuments, you will need to implement a subdocument mapper plugin.
+Two extension points are provided, depending on how you want to index subdocuments:
+
+1. Indexing custom subdocuments per Content
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To index custom subdocuments per Content, implement a service extending
+``Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentSubdocumentMapper`` class,
+defining two methods:
+
+* ``accept(Content $content): bool``
+
+  Here you will receive a Content that is being indexed as an instance of
+  ``eZ\Publish\SPI\Persistence\Content``. Using that object you have to decide whether you want to
+  index custom subdocuments for it or not.
+
+* ``map(Content $content): Document``
+
+  Again you receive an instance of ``eZ\Publish\SPI\Persistence\Content``, which you can use to
+  build and return an array of ``eZ\Publish\SPI\Search\Document`` instances. These represent custom
+  subdocuments that will be indexed under the given Content.
+
+Code example:
+
+.. code-block:: php
+
+    final class MyContentSubdocumentMapper extends ContentSubdocumentMapper
+    {
+        public function accept(Content $content)
+        {
+            return $content->versionInfo->contentInfo->contentTypeId === 42;
+        }
+
+        public function mapDocuments(Content $content)
+        {
+            return [
+                new Document([
+                    'id' => 'unique_id',
+                    'fields' => [
+                        new Field(
+                            'document_type',
+                            'content_subdocument',
+                            new FieldType\IdentifierField()
+                        ),
+                        new Field('price', 5 new FieldType\IntegerField()),
+                    ],
+                ]),
+            ];
+        }
+    }
+
+You also have to configure the mapper in the service container configuration, tagging it with
+``netgen.search.solr.subdocument_mapper.content`` tag so that the system can find it.
+
+.. code-block:: php
+
+    my_content_subdocument_mapper:
+        class: MyContentSubdocumentMapper
+        tags:
+            - {name: netgen.search.solr.subdocument_mapper.content}
+
+2. Indexing custom subdocuments per Content translation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To index custom subdocuments per Content translation, implement a service extending
+``Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentTranslationSubdocumentMapper``
+class, defining two methods:
+
+* ``accept(Content $content, string $languageCode): bool``
+
+  Here you will receive a Content being indexed and a language that it's being indexed in, as an
+  instance of ``eZ\Publish\SPI\Persistence\Content`` and a language code string. Using these
+  parameters you have to decide whether you want to index custom subdocuments for it or not.
+
+* ``map(Content $content, string $languageCode): Document``
+
+  Again you receive an instance of ``eZ\Publish\SPI\Persistence\Content`` and a language code
+  string. You can use these to build and return an array of ``eZ\Publish\SPI\Search\Document``
+  instances, representing custom subdocuments that will be indexed under the given translation of
+  a Content.
+
+Code example:
+
+.. code-block:: php
+
+    final class MyContentTranslationSubdocumentMapper extends ContentSubdocumentMapper
+    {
+        public function accept(Content $content, $languageCode)
+        {
+            $contentTypeId = $content->versionInfo->contentInfo->contentTypeId;
+
+            return $contentTypeId === 42 && $languageCode === 'cro-HR';
+        }
+
+        public function mapDocuments(Content $content, $languageCode)
+        {
+            return [
+                new Document([
+                    'id' => 'unique_subdocument_id',
+                    'fields' => [
+                        new Field(
+                            'document_type',
+                            'content_translation_subdocument',
+                            new FieldType\IdentifierField()
+                        ),
+                        new Field('price', 5 new FieldType\IntegerField()),
+                    ],
+                ]),
+            ];
+        }
+    }
+
+You also have to configure the mapper in the service container configuration, tagging it with
+``netgen.search.solr.subdocument_mapper.content_translation`` tag so that the system can find it.
+
+.. code-block:: php
+
+    my_content_translation_subdocument_mapper:
+        class: MyContentTranslationSubdocumentMapper
+        tags:
+            - {name: netgen.search.solr.subdocument_mapper.content_translation}
+
+.. note::
+
+    It's mandatory to define ``document_type`` field of ``IdentifierField`` type, in every Document
+    you are returning. You must not use ``content`` or ``location`` here, since these are already
+    used by the search engine.
+
+Using custom subdocuments in search
+-----------------------------------
+
+Indexing custom subdocuments would not be very useful without having a way to use them in search.
+For this ``SubdocumentQuery`` criterion is provided. It's constructor accepts two mandatory
+arguments:
+
+1. ``string $documentTypeIdentifier``
+
+  Document type identifier is used to match custom subdocument by it's type.
+
+2. ``Criterion $filter``
+
+  Filter is an instance of a criterion, with following of the standard eZ criteria being supported
+  out of the box:
+
+  * ``LogicalAnd``
+  * ``LogicalNot``
+  * ``LogicalOr``
+  * ``CustomField``
+
+Code example:
+
+.. code-block:: php
+
+    $query = new Query([
+        'filter' => new LogicalAnd([
+            new ContentTypeIdentifier('product'),
+            new SubdocumentQuery(
+                'product_variant',
+                new LogicalAnd([
+                    new CustomField('visible_b', Operator::EQ, true),
+                    new CustomField('price_i', Operator::LT, 40),
+                ])
+            ),
+        ])
+    ]);
+
+    $searchResult = $searchService->findContent($query);
+
+Implementing new criteria for ``SubdocumentQuery``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want to implement additional criteria to use with ``SubdocumentQuery`` just implement is as
+usual. Then tag the visitor service with
+``netgen.search.solr.query.subdocument.criterion_visitor`` tag.

--- a/docs/reference/subdocuments.rst
+++ b/docs/reference/subdocuments.rst
@@ -1,0 +1,4 @@
+Custom Content subdocuments
+===========================
+
+...

--- a/docs/reference/subdocuments.rst
+++ b/docs/reference/subdocuments.rst
@@ -40,7 +40,7 @@ defining two methods:
 
 * ``map(Content $content): Document``
 
-  Again you receive an instance of ``eZ\Publish\SPI\Persistence\Content``, which you can use to
+  Again you will receive an instance of ``eZ\Publish\SPI\Persistence\Content``, which you can use to
   build and return an array of ``eZ\Publish\SPI\Search\Document`` instances. These represent custom
   subdocuments that will be indexed under the given Content.
 
@@ -195,4 +195,4 @@ Implementing new criteria for ``SubdocumentQuery``
 
 If you want to implement additional criteria to use with ``SubdocumentQuery`` just implement is as
 usual. Then tag the visitor service with
-``netgen.search.solr.query.subdocument.criterion_visitor`` tag.
+``netgen.search.solr.query.content.criterion_visitor.subdocument_query`` tag.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx>=1.7.4,<2.0
+sphinx_rtd_theme>=0.3.1,<1.0
+git+https://github.com/fabpot/sphinx-php.git

--- a/lib/API/Values/Content/Query/Criterion/SubdocumentQuery.php
+++ b/lib/API/Values/Content/Query/Criterion/SubdocumentQuery.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
+use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
+
+/**
+ * SubdocumentQuery criterion is used to query Content subdocuments of a specific type.
+ */
+class SubdocumentQuery extends Criterion implements CriterionInterface
+{
+    /**
+     * @param string $documentTypeIdentifier
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $subdocumentCriteria
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function __construct($documentTypeIdentifier, Criterion $subdocumentCriteria)
+    {
+        parent::__construct($documentTypeIdentifier, null, $subdocumentCriteria);
+    }
+
+    public function getSpecifications()
+    {
+        return [
+            new Specifications(Operator::EQ, Specifications::FORMAT_SINGLE),
+        ];
+    }
+
+    public static function createFromQueryBuilder($target, $operator, $value)
+    {
+    }
+}

--- a/lib/API/Values/Content/Query/Criterion/SubdocumentQuery.php
+++ b/lib/API/Values/Content/Query/Criterion/SubdocumentQuery.php
@@ -14,13 +14,13 @@ class SubdocumentQuery extends Criterion implements CriterionInterface
 {
     /**
      * @param string $documentTypeIdentifier
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $subdocumentCriteria
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $filter
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct($documentTypeIdentifier, Criterion $subdocumentCriteria)
+    public function __construct($documentTypeIdentifier, Criterion $filter)
     {
-        parent::__construct($documentTypeIdentifier, null, $subdocumentCriteria);
+        parent::__construct($documentTypeIdentifier, null, $filter);
     }
 
     public function getSpecifications()

--- a/lib/Container/Compiler/AggregateContentSubdocumentMapperPass.php
+++ b/lib/Container/Compiler/AggregateContentSubdocumentMapperPass.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Container\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * This compiler pass will register Content subdocument mappers.
+ *
+ * @see \Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentSubdocumentMapper
+ * @see \Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentSubdocumentMapper\Aggregate
+ */
+final class AggregateContentSubdocumentMapperPass implements CompilerPassInterface
+{
+    private static $aggregateMapperId = 'netgen.search.solr.subdocument_mapper.content.aggregate';
+    private static $mapperTag = 'netgen.search.solr.subdocument_mapper.content';
+
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition(static::$aggregateMapperId)) {
+            return;
+        }
+
+        $aggregateDefinition = $container->getDefinition(static::$aggregateMapperId);
+        $mapperIds = $container->findTaggedServiceIds(static::$mapperTag);
+
+        $this->registerMappers($aggregateDefinition, $mapperIds);
+    }
+
+    private function registerMappers(Definition $definition, array $mapperIds)
+    {
+        foreach (array_keys($mapperIds) as $id) {
+            $definition->addMethodCall('addMapper', [new Reference($id)]);
+        }
+    }
+}

--- a/lib/Container/Compiler/AggregateContentTranslationSubdocumentMapperPass.php
+++ b/lib/Container/Compiler/AggregateContentTranslationSubdocumentMapperPass.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Container\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * This compiler pass will register Content translation subdocument mappers.
+ *
+ * @see \Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentTranslationSubdocumentMapper
+ * @see \Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentTranslationSubdocumentMapper\Aggregate
+ */
+final class AggregateContentTranslationSubdocumentMapperPass implements CompilerPassInterface
+{
+    private static $aggregateMapperId = 'netgen.search.solr.subdocument_mapper.content_translation.aggregate';
+    private static $mapperTag = 'netgen.search.solr.subdocument_mapper.content_translation';
+
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition(static::$aggregateMapperId)) {
+            return;
+        }
+
+        $aggregateDefinition = $container->getDefinition(static::$aggregateMapperId);
+        $mapperIds = $container->findTaggedServiceIds(static::$mapperTag);
+
+        $this->registerMappers($aggregateDefinition, $mapperIds);
+    }
+
+    private function registerMappers(Definition $definition, array $mapperIds)
+    {
+        foreach (array_keys($mapperIds) as $id) {
+            $definition->addMethodCall('addMapper', [new Reference($id)]);
+        }
+    }
+}

--- a/lib/Container/Compiler/AggregateSubdocumentQueryCriterionVisitorPass.php
+++ b/lib/Container/Compiler/AggregateSubdocumentQueryCriterionVisitorPass.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Container\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * This compiler pass will register subdocument Criterion visitors.
+ *
+ * @see \EzSystems\EzPlatformSolrSearchEngine\Query\Common\CriterionVisitor\Aggregate
+ */
+final class AggregateSubdocumentQueryCriterionVisitorPass implements CompilerPassInterface
+{
+    private static $aggregateVisitorId = 'netgen.search.solr.criterion_visitor.subdocument_query.aggregate';
+    private static $visitorTag = 'netgen.search.solr.criterion_visitor.subdocument_query';
+
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition(static::$aggregateVisitorId)) {
+            return;
+        }
+
+        $aggregateDefinition = $container->getDefinition(static::$aggregateVisitorId);
+        $mapperIds = $container->findTaggedServiceIds(static::$visitorTag);
+
+        $this->registerMappers($aggregateDefinition, $mapperIds);
+    }
+
+    private function registerMappers(Definition $definition, array $visitorIds)
+    {
+        foreach (array_keys($visitorIds) as $id) {
+            $definition->addMethodCall('addVisitor', [new Reference($id)]);
+        }
+    }
+}

--- a/lib/Container/Compiler/AggregateSubdocumentQueryCriterionVisitorPass.php
+++ b/lib/Container/Compiler/AggregateSubdocumentQueryCriterionVisitorPass.php
@@ -14,8 +14,8 @@ use Symfony\Component\DependencyInjection\Definition;
  */
 final class AggregateSubdocumentQueryCriterionVisitorPass implements CompilerPassInterface
 {
-    private static $aggregateVisitorId = 'netgen.search.solr.criterion_visitor.subdocument_query.aggregate';
-    private static $visitorTag = 'netgen.search.solr.criterion_visitor.subdocument_query';
+    private static $aggregateVisitorId = 'netgen.search.solr.query.subdocument.criterion_visitor.aggregate';
+    private static $visitorTag = 'netgen.search.solr.query.subdocument.criterion_visitor';
 
     public function process(ContainerBuilder $container)
     {

--- a/lib/Container/Compiler/AggregateSubdocumentQueryCriterionVisitorPass.php
+++ b/lib/Container/Compiler/AggregateSubdocumentQueryCriterionVisitorPass.php
@@ -14,8 +14,8 @@ use Symfony\Component\DependencyInjection\Definition;
  */
 final class AggregateSubdocumentQueryCriterionVisitorPass implements CompilerPassInterface
 {
-    private static $aggregateVisitorId = 'netgen.search.solr.query.subdocument.criterion_visitor.aggregate';
-    private static $visitorTag = 'netgen.search.solr.query.subdocument.criterion_visitor';
+    private static $aggregateVisitorId = 'netgen.search.solr.query.content.criterion_visitor.subdocument_query.aggregate';
+    private static $visitorTag = 'netgen.search.solr.query.content.criterion_visitor.subdocument_query';
 
     public function process(ContainerBuilder $container)
     {

--- a/lib/Container/Compiler/TagSubdocumentCriterionVisitorsPass.php
+++ b/lib/Container/Compiler/TagSubdocumentCriterionVisitorsPass.php
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\Definition;
  */
 final class TagSubdocumentCriterionVisitorsPass implements CompilerPassInterface
 {
-    private static $subdocumentCriterionVisitorTag = 'netgen.search.solr.query.subdocument.criterion_visitor';
+    private static $subdocumentCriterionVisitorTag = 'netgen.search.solr.query.content.criterion_visitor.subdocument_query';
     private static $criterionVisitorIds = [
         'ezpublish.search.solr.query.common.criterion_visitor.logical_and',
         'ezpublish.search.solr.query.common.criterion_visitor.logical_not',

--- a/lib/Container/Compiler/TagSubdocumentCriterionVisitorsPass.php
+++ b/lib/Container/Compiler/TagSubdocumentCriterionVisitorsPass.php
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\Definition;
  */
 final class TagSubdocumentCriterionVisitorsPass implements CompilerPassInterface
 {
-    private static $subdocumentCriterionVisitorTag = 'netgen.search.solr.criterion_visitor.subdocument_query';
+    private static $subdocumentCriterionVisitorTag = 'netgen.search.solr.query.subdocument.criterion_visitor';
     private static $criterionVisitorIds = [
         'ezpublish.search.solr.query.common.criterion_visitor.logical_and',
         'ezpublish.search.solr.query.common.criterion_visitor.logical_not',

--- a/lib/Container/Compiler/TagSubdocumentCriterionVisitorsPass.php
+++ b/lib/Container/Compiler/TagSubdocumentCriterionVisitorsPass.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Container\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * This compiler pass will add 'netgen.search.solr.criterion_visitor.subdocument_query' tag to the
+ * selected eZ Systems provided criterion visitors.
+ */
+final class TagSubdocumentCriterionVisitorsPass implements CompilerPassInterface
+{
+    private static $subdocumentCriterionVisitorTag = 'netgen.search.solr.criterion_visitor.subdocument_query';
+    private static $criterionVisitorIds = [
+        'ezpublish.search.solr.query.common.criterion_visitor.logical_and',
+        'ezpublish.search.solr.query.common.criterion_visitor.logical_not',
+        'ezpublish.search.solr.query.common.criterion_visitor.logical_or',
+        'ezpublish.search.solr.query.common.criterion_visitor.custom_field_in',
+        'ezpublish.search.solr.query.common.criterion_visitor.custom_field_range',
+    ];
+
+    public function process(ContainerBuilder $container)
+    {
+        foreach (static::$criterionVisitorIds as $id) {
+            if (!$container->hasDefinition($id)) {
+                continue;
+            }
+
+            $definition = $container->getDefinition($id);
+            $definition->addTag(static::$subdocumentCriterionVisitorTag);
+        }
+    }
+}

--- a/lib/Core/Search/Common/FieldValueMapper/IdentifierMapper.php
+++ b/lib/Core/Search/Common/FieldValueMapper/IdentifierMapper.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Common\FieldValueMapper;
+
+use eZ\Publish\Core\Search\Common\FieldValueMapper;
+use eZ\Publish\SPI\Search\FieldType\IdentifierField;
+use eZ\Publish\SPI\Search\Field;
+
+/**
+ * Common identifier field value mapper implementation, performing different pattern
+ * replacement than the original.
+ *
+ * @see \eZ\Publish\Core\Search\Common\FieldValueMapper\IdentifierMapper
+ */
+final class IdentifierMapper extends FieldValueMapper
+{
+    public function canMap(Field $field)
+    {
+        return $field->type instanceof IdentifierField;
+    }
+
+    public function map(Field $field)
+    {
+        return $this->convert($field->value);
+    }
+
+    protected function convert($value)
+    {
+        // Remove everything except alphanumeric characters, slash (/), underscore (_) and minus (-)
+        return preg_replace('([^A-Za-z0-9_\-/]+)', '', $value);
+    }
+}

--- a/lib/Core/Search/Solr/DocumentMapper.php
+++ b/lib/Core/Search/Solr/DocumentMapper.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr;
+
+use eZ\Publish\SPI\Persistence\Content;
+use EzSystems\EzPlatformSolrSearchEngine\DocumentMapper as DocumentMapperInterface;
+use Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentSubdocumentMapper;
+use Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentTranslationSubdocumentMapper;
+
+/**
+ * Indexes information on whether Content field value is empty.
+ */
+final class DocumentMapper implements DocumentMapperInterface
+{
+    /**
+     * @var \EzSystems\EzPlatformSolrSearchEngine\DocumentMapper
+     */
+    private $nativeDocumentMapper;
+
+    /**
+     * @var \Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentSubdocumentMapper
+     */
+    private $contentSubdocumentMapper;
+
+    /**
+     * @var \Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentTranslationSubdocumentMapper
+     */
+    private $contentTranslationSubdocumentMapper;
+
+    /**
+     * @param \EzSystems\EzPlatformSolrSearchEngine\DocumentMapper $nativeDocumentMapper
+     * @param \Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentSubdocumentMapper $contentSubdocumentMapper
+     * @param \Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentTranslationSubdocumentMapper $contentTranslationSubdocumentMapper
+     */
+    public function __construct(
+        DocumentMapperInterface $nativeDocumentMapper,
+        ContentSubdocumentMapper $contentSubdocumentMapper,
+        ContentTranslationSubdocumentMapper $contentTranslationSubdocumentMapper
+    ) {
+        $this->nativeDocumentMapper = $nativeDocumentMapper;
+        $this->contentSubdocumentMapper = $contentSubdocumentMapper;
+        $this->contentTranslationSubdocumentMapper = $contentTranslationSubdocumentMapper;
+    }
+
+    public function mapContentBlock(Content $content)
+    {
+        $block = $this->nativeDocumentMapper->mapContentBlock($content);
+        $subdocuments = $this->getContentSubdocuments($content);
+
+        foreach ($block as $contentDocument) {
+            $translationSubdocuments = $this->getContentTranslationSubdocuments($content, $contentDocument->languageCode);
+
+            $contentDocument->documents = array_merge(
+                $contentDocument->documents,
+                $subdocuments,
+                $translationSubdocuments
+            );
+        }
+
+        return $block;
+    }
+
+    /**
+     * @param \eZ\Publish\SPI\Persistence\Content $content
+     *
+     * @return array|\eZ\Publish\SPI\Search\Document[]
+     */
+    private function getContentSubdocuments(Content $content)
+    {
+        if ($this->contentSubdocumentMapper->accept($content)) {
+            return $this->contentSubdocumentMapper->mapDocuments($content);
+        }
+
+        return [];
+    }
+
+    /**
+     * @param \eZ\Publish\SPI\Persistence\Content $content
+     * @param string $languageCode
+     *
+     * @return array|\eZ\Publish\SPI\Search\Document[]
+     */
+    private function getContentTranslationSubdocuments(Content $content, $languageCode)
+    {
+        if ($this->contentTranslationSubdocumentMapper->accept($content, $languageCode)) {
+            return $this->contentTranslationSubdocumentMapper->mapDocuments($content, $languageCode);
+        }
+
+        return [];
+    }
+
+    public function generateContentDocumentId($contentId, $languageCode = null)
+    {
+        return $this->nativeDocumentMapper->generateContentDocumentId($contentId, $languageCode);
+    }
+
+    public function generateLocationDocumentId($locationId, $languageCode = null)
+    {
+        return $this->nativeDocumentMapper->generateLocationDocumentId($locationId, $languageCode);
+    }
+}

--- a/lib/Core/Search/Solr/DocumentMapper.php
+++ b/lib/Core/Search/Solr/DocumentMapper.php
@@ -45,6 +45,7 @@ final class DocumentMapper implements DocumentMapperInterface
     public function mapContentBlock(Content $content)
     {
         $block = $this->nativeDocumentMapper->mapContentBlock($content);
+        $this->escapeDocumentIds($block);
         $subdocuments = $this->getContentSubdocuments($content);
 
         foreach ($block as $contentDocument) {
@@ -58,6 +59,18 @@ final class DocumentMapper implements DocumentMapperInterface
         }
 
         return $block;
+    }
+
+    /**
+     * @param \eZ\Publish\SPI\Search\Document[] $documents
+     */
+    private function escapeDocumentIds(array $documents)
+    {
+        foreach ($documents as $document) {
+            $document->id = preg_replace('([^A-Za-z0-9/]+)', '', $document->id);
+
+            $this->escapeDocumentIds($document->documents);
+        }
     }
 
     /**

--- a/lib/Core/Search/Solr/DocumentMapper.php
+++ b/lib/Core/Search/Solr/DocumentMapper.php
@@ -8,7 +8,11 @@ use Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentSubdo
 use Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentTranslationSubdocumentMapper;
 
 /**
- * Indexes information on whether Content field value is empty.
+ * This DocumentMapper implementation adds support for indexing custom Content subdocuments.
+ *
+ * @see \EzSystems\EzPlatformSolrSearchEngine\DocumentMapper
+ * @see \Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentSubdocumentMapper
+ * @see \Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentTranslationSubdocumentMapper
  */
 final class DocumentMapper implements DocumentMapperInterface
 {

--- a/lib/Core/Search/Solr/Query/Common/CriterionVisitor/SubdocumentQuery.php
+++ b/lib/Core/Search/Solr/Query/Common/CriterionVisitor/SubdocumentQuery.php
@@ -33,7 +33,7 @@ final class SubdocumentQuery extends CriterionVisitor
 
     public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null)
     {
-        /** @var \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\SubdocumentQuery $query */
+        /** @var \eZ\Publish\API\Repository\Values\Content\Query\Criterion $query */
         $query = $criterion->value;
         $identifier = $criterion->target;
 

--- a/lib/Core/Search/Solr/Query/Common/CriterionVisitor/SubdocumentQuery.php
+++ b/lib/Core/Search/Solr/Query/Common/CriterionVisitor/SubdocumentQuery.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\SubdocumentQuery as SubdocumentQueryCriterion;
+
+/**
+ * Visits the SubdocumentQuery criterion.
+ *
+ * @see \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\SubdocumentQuery
+ */
+final class SubdocumentQuery extends CriterionVisitor
+{
+    /**
+     * @var \EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor
+     */
+    private $subdocumentQueryCriterionVisitor;
+
+    /**
+     * @param \EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor $subdocumentQueryCriterionVisitor
+     */
+    public function __construct(CriterionVisitor $subdocumentQueryCriterionVisitor)
+    {
+        $this->subdocumentQueryCriterionVisitor = $subdocumentQueryCriterionVisitor;
+    }
+
+    public function canVisit(Criterion $criterion)
+    {
+        return $criterion instanceof SubdocumentQueryCriterion;
+    }
+
+    public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null)
+    {
+        /** @var \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\SubdocumentQuery $query */
+        $query = $criterion->value;
+        $identifier = $criterion->target;
+
+        $condition = $this->escapeQuote(
+            $this->subdocumentQueryCriterionVisitor->visit($query)
+        );
+
+        $condition = str_replace('/', '\\/', $condition);
+
+        return "{!parent which='document_type_id:content' v='document_type_id:{$identifier} AND {$condition}'}";
+    }
+}

--- a/lib/Core/Search/Solr/Query/Content/CriterionVisitor/SubdocumentQuery.php
+++ b/lib/Core/Search/Solr/Query/Content/CriterionVisitor/SubdocumentQuery.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor;
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Content\CriterionVisitor;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor;

--- a/lib/Core/Search/Solr/SubdocumentMapper/ContentSubdocumentMapper.php
+++ b/lib/Core/Search/Solr/SubdocumentMapper/ContentSubdocumentMapper.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper;
+
+use eZ\Publish\SPI\Persistence\Content;
+
+/**
+ * Maps Content to an array of subdocuments.
+ */
+abstract class ContentSubdocumentMapper
+{
+    /**
+     * Indicate if the mapper accepts the given $content for mapping.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content $content
+     *
+     * @return bool
+     */
+    abstract public function accept(Content $content);
+
+    /**
+     * Maps given Content to a Document.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content $content
+     *
+     * @return \eZ\Publish\SPI\Search\Document[]
+     */
+    abstract public function mapDocuments(Content $content);
+}

--- a/lib/Core/Search/Solr/SubdocumentMapper/ContentSubdocumentMapper/Aggregate.php
+++ b/lib/Core/Search/Solr/SubdocumentMapper/ContentSubdocumentMapper/Aggregate.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentSubdocumentMapper;
+
+use eZ\Publish\SPI\Persistence\Content;
+use Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentSubdocumentMapper;
+
+/**
+ * Aggregate implementation of Content subdocument mapper.
+ */
+final class Aggregate extends ContentSubdocumentMapper
+{
+    /**
+     * An array of aggregated subdocument mappers.
+     *
+     * @var \Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentSubdocumentMapper[]
+     */
+    protected $mappers = [];
+
+    /**
+     * @param \Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentSubdocumentMapper[] $mappers
+     */
+    public function __construct(array $mappers = [])
+    {
+        foreach ($mappers as $mapper) {
+            $this->addMapper($mapper);
+        }
+    }
+
+    /**
+     * Adds given $mapper to the internal collection.
+     *
+     * @param \Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentSubdocumentMapper $mapper
+     */
+    public function addMapper(ContentSubdocumentMapper $mapper)
+    {
+        $this->mappers[] = $mapper;
+    }
+
+    public function accept(Content $content)
+    {
+        return true;
+    }
+
+    public function mapDocuments(Content $content)
+    {
+        $documentsGrouped = [[]];
+
+        foreach ($this->mappers as $mapper) {
+            if ($mapper->accept($content)) {
+                $documentsGrouped[] = $mapper->mapDocuments($content);
+            }
+        }
+
+        return array_merge(...$documentsGrouped);
+    }
+}

--- a/lib/Core/Search/Solr/SubdocumentMapper/ContentTranslationSubdocumentMapper.php
+++ b/lib/Core/Search/Solr/SubdocumentMapper/ContentTranslationSubdocumentMapper.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper;
+
+use eZ\Publish\SPI\Persistence\Content;
+
+/**
+ * Maps Content in a specific language to an array of subdocuments.
+ */
+abstract class ContentTranslationSubdocumentMapper
+{
+    /**
+     * Indicate if the mapper accepts the given $content for mapping.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content $content
+     * @param string $languageCode
+     *
+     * @return bool
+     */
+    abstract public function accept(Content $content, $languageCode);
+
+    /**
+     * Maps given Content to a Document.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content $content
+     * @param string $languageCode
+     *
+     * @return \eZ\Publish\SPI\Search\Document[]
+     */
+    abstract public function mapDocuments(Content $content, $languageCode);
+}

--- a/lib/Core/Search/Solr/SubdocumentMapper/ContentTranslationSubdocumentMapper/Aggregate.php
+++ b/lib/Core/Search/Solr/SubdocumentMapper/ContentTranslationSubdocumentMapper/Aggregate.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentTranslationSubdocumentMapper;
+
+use eZ\Publish\SPI\Persistence\Content;
+use Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentTranslationSubdocumentMapper;
+
+/**
+ * Aggregate implementation of Content translation subdocument mapper.
+ */
+final class Aggregate extends ContentTranslationSubdocumentMapper
+{
+    /**
+     * An array of aggregated subdocument mappers.
+     *
+     * @var \Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentTranslationSubdocumentMapper[]
+     */
+    protected $mappers = [];
+
+    /**
+     * @param \Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentTranslationSubdocumentMapper[] $mappers
+     */
+    public function __construct(array $mappers = [])
+    {
+        foreach ($mappers as $mapper) {
+            $this->addMapper($mapper);
+        }
+    }
+
+    /**
+     * Adds given $mapper to the internal collection.
+     *
+     * @param \Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentTranslationSubdocumentMapper $mapper
+     */
+    public function addMapper(ContentTranslationSubdocumentMapper $mapper)
+    {
+        $this->mappers[] = $mapper;
+    }
+
+    public function accept(Content $content, $languageCode)
+    {
+        return true;
+    }
+
+    public function mapDocuments(Content $content, $languageCode)
+    {
+        $documentsGrouped = [[]];
+
+        foreach ($this->mappers as $mapper) {
+            if ($mapper->accept($content, $languageCode)) {
+                $documentsGrouped[] = $mapper->mapDocuments($content, $languageCode);
+            }
+        }
+
+        return array_merge(...$documentsGrouped);
+    }
+}

--- a/lib/Resources/config/search/common.yml
+++ b/lib/Resources/config/search/common.yml
@@ -1,0 +1,2 @@
+imports:
+    - {resource: common/field_value_mappers.yml}

--- a/lib/Resources/config/search/common/field_value_mappers.yml
+++ b/lib/Resources/config/search/common/field_value_mappers.yml
@@ -1,0 +1,5 @@
+services:
+    ezpublish.search.common.field_value_mapper.identifier:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Common\FieldValueMapper\IdentifierMapper
+        tags:
+            - {name: ezpublish.search.common.field_value_mapper}

--- a/lib/Resources/config/search/solr.yml
+++ b/lib/Resources/config/search/solr.yml
@@ -1,34 +1,13 @@
+imports:
+    - {resource: solr/criterion_visitors.yml}
+    - {resource: solr/field_mappers.yml}
+    - {resource: solr/subdocument_mappers.yml}
+
 services:
-    netgen.search.solr.query.common.criterion_visitor.object_state_identifier:
-        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor\ObjectStateIdentifier
+    netgen.search.solr.document_mapper:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\DocumentMapper
+        decorates: ezpublish.search.solr.document_mapper
         arguments:
-            - '@ezpublish.spi.persistence.object_state_handler'
-        tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
-
-    netgen.search.solr.query.common.criterion_visitor.section_identifier:
-        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor\SectionIdentifier
-        arguments:
-            - '@ezpublish.spi.persistence.section_handler'
-        tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
-
-    netgen.search.solr.criterion_visitor.is_field_empty:
-        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor\IsFieldEmpty
-        arguments:
-            - '@ezpublish.spi.persistence.content_type_handler'
-            - '@ezpublish.search.common.field_name_generator'
-        tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
-            - {name: ezpublish.search.solr.query.location.criterion_visitor}
-
-    netgen.search.solr.field_mapper.content.is_field_empty:
-        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\FieldMapper\ContentTranslation\IsFieldEmptyFieldMapper
-        arguments:
-            - '@ezpublish.spi.persistence.content_type_handler'
-            - '@ezpublish.search.common.field_name_generator'
-            - '@ezpublish.persistence.field_type_registry'
-        tags:
-            - {name: ezpublish.search.solr.field_mapper.block_translation}
+            - '@netgen.search.solr.document_mapper.inner'
+            - '@netgen.search.solr.subdocument_mapper.content.aggregate'
+            - '@netgen.search.solr.subdocument_mapper.content_translation.aggregate'

--- a/lib/Resources/config/search/solr/criterion_visitors.yml
+++ b/lib/Resources/config/search/solr/criterion_visitors.yml
@@ -15,7 +15,7 @@ services:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
-    netgen.search.solr.criterion_visitor.is_field_empty:
+    netgen.search.solr.query.common.criterion_visitor.is_field_empty:
         class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor\IsFieldEmpty
         arguments:
             - '@ezpublish.spi.persistence.content_type_handler'
@@ -24,14 +24,14 @@ services:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
-    netgen.search.solr.criterion_visitor.subdocument_query:
+    netgen.search.solr.query.subdocument.criterion_visitor.subdocument_query:
         class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor\SubdocumentQuery
         arguments:
-            - '@netgen.search.solr.criterion_visitor.subdocument_query.aggregate'
+            - '@netgen.search.solr.query.subdocument.criterion_visitor.aggregate'
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
-    # Note: services tagged with 'netgen.search.solr.criterion_visitor.subdocument_query'
+    # Note: services tagged with 'netgen.search.solr.query.subdocument.criterion_visitor'
     # are registered to this one using container compiler pass
-    netgen.search.solr.criterion_visitor.subdocument_query.aggregate:
+    netgen.search.solr.query.subdocument.criterion_visitor.aggregate:
         class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\CriterionVisitor\Aggregate

--- a/lib/Resources/config/search/solr/criterion_visitors.yml
+++ b/lib/Resources/config/search/solr/criterion_visitors.yml
@@ -1,0 +1,37 @@
+services:
+    netgen.search.solr.query.common.criterion_visitor.object_state_identifier:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor\ObjectStateIdentifier
+        arguments:
+            - '@ezpublish.spi.persistence.object_state_handler'
+        tags:
+            - {name: ezpublish.search.solr.query.content.criterion_visitor}
+            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+
+    netgen.search.solr.query.common.criterion_visitor.section_identifier:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor\SectionIdentifier
+        arguments:
+            - '@ezpublish.spi.persistence.section_handler'
+        tags:
+            - {name: ezpublish.search.solr.query.content.criterion_visitor}
+            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+
+    netgen.search.solr.criterion_visitor.is_field_empty:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor\IsFieldEmpty
+        arguments:
+            - '@ezpublish.spi.persistence.content_type_handler'
+            - '@ezpublish.search.common.field_name_generator'
+        tags:
+            - {name: ezpublish.search.solr.query.content.criterion_visitor}
+            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+
+    netgen.search.solr.criterion_visitor.subdocument_query:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor\SubdocumentQuery
+        arguments:
+            - '@netgen.search.solr.criterion_visitor.subdocument_query.aggregate'
+        tags:
+            - {name: ezpublish.search.solr.query.content.criterion_visitor}
+
+    # Note: services tagged with 'netgen.search.solr.criterion_visitor.subdocument_query'
+    # are registered to this one using container compiler pass
+    netgen.search.solr.criterion_visitor.subdocument_query.aggregate:
+        class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\CriterionVisitor\Aggregate

--- a/lib/Resources/config/search/solr/criterion_visitors.yml
+++ b/lib/Resources/config/search/solr/criterion_visitors.yml
@@ -25,7 +25,7 @@ services:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     netgen.search.solr.query.content.criterion_visitor.subdocument_query:
-        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor\SubdocumentQuery
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Content\CriterionVisitor\SubdocumentQuery
         arguments:
             - '@netgen.search.solr.query.content.criterion_visitor.subdocument_query.aggregate'
         tags:

--- a/lib/Resources/config/search/solr/criterion_visitors.yml
+++ b/lib/Resources/config/search/solr/criterion_visitors.yml
@@ -24,14 +24,14 @@ services:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
-    netgen.search.solr.query.subdocument.criterion_visitor.subdocument_query:
+    netgen.search.solr.query.content.criterion_visitor.subdocument_query:
         class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor\SubdocumentQuery
         arguments:
-            - '@netgen.search.solr.query.subdocument.criterion_visitor.aggregate'
+            - '@netgen.search.solr.query.content.criterion_visitor.subdocument_query.aggregate'
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
-    # Note: services tagged with 'netgen.search.solr.query.subdocument.criterion_visitor'
+    # Note: services tagged with 'netgen.search.solr.query.content.criterion_visitor.subdocument_query'
     # are registered to this one using container compiler pass
-    netgen.search.solr.query.subdocument.criterion_visitor.aggregate:
+    netgen.search.solr.query.content.criterion_visitor.subdocument_query.aggregate:
         class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\CriterionVisitor\Aggregate

--- a/lib/Resources/config/search/solr/field_mappers.yml
+++ b/lib/Resources/config/search/solr/field_mappers.yml
@@ -1,0 +1,9 @@
+services:
+    netgen.search.solr.field_mapper.content.is_field_empty:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\FieldMapper\ContentTranslation\IsFieldEmptyFieldMapper
+        arguments:
+            - '@ezpublish.spi.persistence.content_type_handler'
+            - '@ezpublish.search.common.field_name_generator'
+            - '@ezpublish.persistence.field_type_registry'
+        tags:
+            - {name: ezpublish.search.solr.field_mapper.block_translation}

--- a/lib/Resources/config/search/solr/subdocument_mappers.yml
+++ b/lib/Resources/config/search/solr/subdocument_mappers.yml
@@ -1,0 +1,10 @@
+services:
+    # Note: services tagged with 'netgen.search.solr.subdocument_mapper.content'
+    # are registered to this one using container compiler pass
+    netgen.search.solr.subdocument_mapper.content.aggregate:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentSubdocumentMapper\Aggregate
+
+    # Note: services tagged with 'netgen.search.solr.subdocument_mapper.content_translation'
+    # are registered to this one using container compiler pass
+    netgen.search.solr.subdocument_mapper.content_translation.aggregate:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentTranslationSubdocumentMapper\Aggregate

--- a/phpunit-integration-legacy.xml
+++ b/phpunit-integration-legacy.xml
@@ -13,6 +13,7 @@
             <directory suffix="Test.php">./tests/</directory>
             <!-- Exclude tests not supported with Legacy search engine -->
             <exclude>tests/lib/API/IsFieldEmptyCriterionTest.php</exclude>
+            <exclude>tests/lib/API/SubdocumentQueryCriterionTest.php</exclude>
         </testsuite>
     </testsuites>
     <filter>

--- a/tests/lib/API/SubdocumentQueryCriterionTest.php
+++ b/tests/lib/API/SubdocumentQueryCriterionTest.php
@@ -12,7 +12,6 @@ use eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentId as Conte
 use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\SubdocumentQuery;
 
 /**
- * @group xxx
  * @see \Netgen\EzPlatformSearchExtra\Tests\Implementation\Solr\SubdocumentMapper\TestContentSubdocumentMapper
  * @see \Netgen\EzPlatformSearchExtra\Tests\Implementation\Solr\SubdocumentMapper\TestContentTranslationSubdocumentMapper
  */

--- a/tests/lib/API/SubdocumentQueryCriterionTest.php
+++ b/tests/lib/API/SubdocumentQueryCriterionTest.php
@@ -1,0 +1,298 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Tests\API;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentId;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\CustomField;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalNot;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentId as ContentIdSortClause;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\SubdocumentQuery;
+
+/**
+ * @group xxx
+ * @see \Netgen\EzPlatformSearchExtra\Tests\Implementation\Solr\SubdocumentMapper\TestContentSubdocumentMapper
+ * @see \Netgen\EzPlatformSearchExtra\Tests\Implementation\Solr\SubdocumentMapper\TestContentTranslationSubdocumentMapper
+ */
+class SubdocumentQueryCriterionTest extends BaseCriterionTest
+{
+    public function providerForTestFind()
+    {
+        return [
+            [
+                new Query([
+                    'filter' => new LogicalAnd([
+                        new ContentId([4, 12, 13, 42, 59]),
+                        new SubdocumentQuery(
+                            'test_content_subdocument',
+                            new LogicalAnd([
+                                new CustomField('visible_b', Operator::EQ, true),
+                                new CustomField('price_i', Operator::EQ, 40),
+                            ])
+                        ),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [],
+                [12],
+            ],
+            [
+                new Query([
+                    'filter' => new LogicalAnd([
+                        new ContentId([4, 12, 13, 42, 59]),
+                        new SubdocumentQuery(
+                            'test_content_subdocument',
+                            new LogicalNot(
+                                new LogicalAnd([
+                                    new CustomField('visible_b', Operator::EQ, true),
+                                    new CustomField('price_i', Operator::EQ, 40),
+                                ])
+                            )
+                        ),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [],
+                [12, 42],
+            ],
+            [
+                new Query([
+                    'filter' => new LogicalAnd([
+                        new ContentId([4, 12, 13, 42, 59]),
+                        new SubdocumentQuery(
+                            'test_content_subdocument',
+                            new LogicalNot(
+                                new LogicalAnd([
+                                    new CustomField('visible_b', Operator::EQ, false),
+                                    new CustomField('price_i', Operator::EQ, 50),
+                                ])
+                            )
+                        ),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [],
+                [12, 42],
+            ],
+            [
+                new Query([
+                    'filter' => new LogicalAnd([
+                        new ContentId([4, 12, 13, 42, 59]),
+                        new LogicalNot(
+                            new SubdocumentQuery(
+                                'test_content_subdocument',
+                                new LogicalAnd([
+                                    new CustomField('visible_b', Operator::EQ, true),
+                                    new CustomField('price_i', Operator::EQ, 40),
+                                ])
+                            )
+                        ),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [],
+                [13, 4, 42, 59],
+            ],
+            [
+                new Query([
+                    'filter' => new LogicalAnd([
+                        new ContentId([4, 12, 13, 42, 59]),
+                        new LogicalNot(
+                            new SubdocumentQuery(
+                                'test_content_subdocument',
+                                new LogicalAnd([
+                                    new CustomField('visible_b', Operator::EQ, false),
+                                    new CustomField('price_i', Operator::EQ, 50),
+                                ])
+                            )
+                        ),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [],
+                [13, 4, 59],
+            ],
+            [
+                new Query([
+                    'filter' => new LogicalAnd([
+                        new ContentId([4, 12, 13, 42, 59]),
+                        new SubdocumentQuery(
+                            'test_content_translation_subdocument',
+                            new CustomField('visible_b', Operator::EQ, true)
+                        ),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [],
+                [],
+            ],
+            [
+                new Query([
+                    'filter' => new LogicalAnd([
+                        new ContentId([4, 12, 13, 42, 59]),
+                        new SubdocumentQuery(
+                            'test_content_translation_subdocument',
+                            new CustomField('visible_b', Operator::EQ, true)
+                        ),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                ['languages' => ['ger-DE']],
+                [4, 59],
+            ],
+            [
+                new Query([
+                    'filter' => new LogicalAnd([
+                        new ContentId([4, 12, 13, 42, 59]),
+                        new SubdocumentQuery(
+                            'test_content_translation_subdocument',
+                            new LogicalAnd([
+                                new CustomField('visible_b', Operator::EQ, true),
+                                new CustomField('price_i', Operator::EQ, 40),
+                            ])
+                        ),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                ['languages' => ['ger-DE']],
+                [59],
+            ],
+            [
+                new Query([
+                    'filter' => new LogicalAnd([
+                        new ContentId([4, 12, 13, 42, 59]),
+                        new SubdocumentQuery(
+                            'test_content_translation_subdocument',
+                            new LogicalNot(
+                                new LogicalAnd([
+                                    new CustomField('visible_b', Operator::EQ, true),
+                                    new CustomField('price_i', Operator::EQ, 40),
+                                ])
+                            )
+                        ),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                ['languages' => ['ger-DE']],
+                [4, 59],
+            ],
+            [
+                new Query([
+                    'filter' => new LogicalAnd([
+                        new ContentId([4, 12, 13, 42, 59]),
+                        new SubdocumentQuery(
+                            'test_content_translation_subdocument',
+                            new LogicalNot(
+                                new LogicalAnd([
+                                    new CustomField('visible_b', Operator::EQ, false),
+                                    new CustomField('price_i', Operator::EQ, 50),
+                                ])
+                            )
+                        ),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                ['languages' => ['ger-DE']],
+                [4, 59],
+            ],
+            [
+                new Query([
+                    'filter' => new LogicalAnd([
+                        new ContentId([4, 12, 13, 42, 59]),
+                        new LogicalNot(
+                            new SubdocumentQuery(
+                                'test_content_translation_subdocument',
+                                new LogicalAnd([
+                                    new CustomField('visible_b', Operator::EQ, true),
+                                    new CustomField('price_i', Operator::EQ, 40),
+                                ])
+                            )
+                        ),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                ['languages' => ['ger-DE']],
+                [12, 13, 4, 42],
+            ],
+            [
+                new Query([
+                    'filter' => new LogicalAnd([
+                        new ContentId([4, 12, 13, 42, 59]),
+                        new LogicalNot(
+                            new SubdocumentQuery(
+                                'test_content_translation_subdocument',
+                                new LogicalAnd([
+                                    new CustomField('visible_b', Operator::EQ, false),
+                                    new CustomField('price_i', Operator::EQ, 50),
+                                ])
+                            )
+                        ),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                ['languages' => ['ger-DE']],
+                [12, 13, 42],
+            ],
+        ];
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testPrepareTestFixtures()
+    {
+        $repository = $this->getRepository();
+        $contentService = $repository->getContentService();
+
+        $contentInfo = $contentService->loadContentInfo(10);
+        $draft = $contentService->createContentDraft($contentInfo);
+        $contentService->publishVersion($draft->versionInfo);
+
+        $contentInfo = $contentService->loadContentInfo(14);
+        $draft = $contentService->createContentDraft($contentInfo);
+        $contentService->publishVersion($draft->versionInfo);
+
+        $contentInfo = $contentService->loadContentInfo(4);
+        $draft = $contentService->createContentDraft($contentInfo);
+        $updateStruct = $contentService->newContentUpdateStruct();
+        $updateStruct->setField('name', 'Benutzer', 'ger-DE');
+        $contentService->updateContent($draft->versionInfo, $updateStruct);
+        $contentService->publishVersion($draft->versionInfo);
+
+        $contentInfo = $contentService->loadContentInfo(59);
+        $draft = $contentService->createContentDraft($contentInfo);
+        $updateStruct = $contentService->newContentUpdateStruct();
+        $updateStruct->setField('name', 'Partner', 'ger-DE');
+        $contentService->updateContent($draft->versionInfo, $updateStruct);
+        $contentService->publishVersion($draft->versionInfo);
+
+        $this->refreshSearch($repository);
+
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @dataProvider providerForTestFind
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     * @param array $languageFilter
+     * @param array $expectedIds
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testFindContent(Query $query, array $languageFilter, array $expectedIds)
+    {
+        $searchService = $this->getSearchService(false);
+
+        $searchResult = $searchService->findContentInfo($query, $languageFilter);
+
+        $this->assertSearchResultContentIds($searchResult, $expectedIds);
+    }
+}

--- a/tests/lib/Implementation/Common/Slot/TestSubdocumentPublishVersion.php
+++ b/tests/lib/Implementation/Common/Slot/TestSubdocumentPublishVersion.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Tests\Implementation\Common\Slot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+use eZ\Publish\Core\Search\Common\Slot;
+
+class TestSubdocumentPublishVersion extends Slot
+{
+    /**
+     * Receive the given $signal and react on it.
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function receive(Signal $signal)
+    {
+        if (!$signal instanceof Signal\ContentService\PublishVersionSignal) {
+            return;
+        }
+
+        $contentHandler = $this->persistenceHandler->contentHandler();
+        $content = $contentHandler->load($signal->contentId, $signal->versionNo);
+        $contentInfo = $content->versionInfo->contentInfo;
+        $contentType = $this->persistenceHandler->contentTypeHandler()->load($contentInfo->contentTypeId);
+
+        if ($contentType->identifier !== 'user') {
+            return;
+        }
+
+        $parentLocation = $this->persistenceHandler->locationHandler()->load($contentInfo->mainLocationId);
+        $parentContentInfo = $contentHandler->loadContentInfo($parentLocation->contentId);
+        $parentContentType = $this->persistenceHandler->contentTypeHandler()->load($parentContentInfo->contentTypeId);
+
+        if ($parentContentType->identifier !== 'user_group') {
+            return;
+        }
+
+        $this->searchHandler->indexContent(
+            $contentHandler->load($parentContentInfo->id, $parentContentInfo->currentVersionNo)
+        );
+    }
+}

--- a/tests/lib/Implementation/Solr/SubdocumentMapper/TestContentSubdocumentMapper.php
+++ b/tests/lib/Implementation/Solr/SubdocumentMapper/TestContentSubdocumentMapper.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Tests\Implementation\Solr\SubdocumentMapper;
+
+use eZ\Publish\SPI\Persistence\Content;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType;
+use eZ\Publish\SPI\Search\Document;
+use Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentSubdocumentMapper;
+
+/**
+ * Note: here we  are only simulating indexing children data.
+ */
+class TestContentSubdocumentMapper extends ContentSubdocumentMapper
+{
+    static private $dataMap = [
+        // Administrator Users
+        '12' => [
+            0 => [
+                'visible' => true,
+                'price' => 40,
+            ],
+            1 => [
+                'visible' => false,
+                'price' => 50,
+            ],
+        ],
+        // Anonymous Users
+        '42' => [
+            0 => [
+                'visible' => true,
+                'price' => 60,
+            ],
+            1 => [
+                'visible' => false,
+                'price' => 50,
+            ],
+        ],
+    ];
+
+    public function accept(Content $content)
+    {
+        return array_key_exists($content->versionInfo->contentInfo->id, static::$dataMap);
+    }
+
+    public function mapDocuments(Content $content)
+    {
+        return [
+            new Document([
+                'id' => uniqid('test_content_subdocument_', false),
+                'fields' => [
+                    new Field(
+                        'document_type',
+                        'test_content_subdocument',
+                        new FieldType\IdentifierField()
+                    ),
+                    new Field(
+                        'visible',
+                        static::$dataMap[$content->versionInfo->contentInfo->id][0]['visible'],
+                        new FieldType\BooleanField()
+                    ),
+                    new Field(
+                        'price',
+                        static::$dataMap[$content->versionInfo->contentInfo->id][0]['price'],
+                        new FieldType\IntegerField()
+                    ),
+                ],
+            ]),
+            new Document([
+                'id' => uniqid('test_content_subdocument_', false),
+                'fields' => [
+                    new Field(
+                        'document_type',
+                        'test_content_subdocument',
+                        new FieldType\IdentifierField()
+                    ),
+                    new Field(
+                        'visible',
+                        static::$dataMap[$content->versionInfo->contentInfo->id][1]['visible'],
+                        new FieldType\BooleanField()
+                    ),
+                    new Field(
+                        'price',
+                        static::$dataMap[$content->versionInfo->contentInfo->id][1]['price'],
+                        new FieldType\IntegerField()
+                    ),
+                ],
+            ]),
+        ];
+    }
+}

--- a/tests/lib/Implementation/Solr/SubdocumentMapper/TestContentTranslationSubdocumentMapper.php
+++ b/tests/lib/Implementation/Solr/SubdocumentMapper/TestContentTranslationSubdocumentMapper.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Tests\Implementation\Solr\SubdocumentMapper;
+
+use eZ\Publish\SPI\Persistence\Content;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType;
+use eZ\Publish\SPI\Search\Document;
+use Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentTranslationSubdocumentMapper;
+
+class TestContentTranslationSubdocumentMapper extends ContentTranslationSubdocumentMapper
+{
+    static private $dataMap = [
+        // Users
+        '4' => [
+            0 => [
+                'visible' => true,
+                'price' => 60,
+            ],
+            1 => [
+                'visible' => false,
+                'price' => 50,
+            ],
+        ],
+        // Partners
+        '59' => [
+            0 => [
+                'visible' => true,
+                'price' => 40,
+            ],
+            1 => [
+                'visible' => false,
+                'price' => 50,
+            ],
+        ],
+    ];
+
+    public function accept(Content $content, $languageCode)
+    {
+        return $languageCode === 'ger-DE' && array_key_exists($content->versionInfo->contentInfo->id, static::$dataMap);
+    }
+
+    public function mapDocuments(Content $content, $languageCode)
+    {
+        return [
+            new Document([
+                'id' => uniqid('test_content_translation_subdocument_', false),
+                'fields' => [
+                    new Field(
+                        'document_type',
+                        'test_content_translation_subdocument',
+                        new FieldType\IdentifierField()
+                    ),
+                    new Field(
+                        'visible',
+                        static::$dataMap[$content->versionInfo->contentInfo->id][0]['visible'],
+                        new FieldType\BooleanField()
+                    ),
+                    new Field(
+                        'price',
+                        static::$dataMap[$content->versionInfo->contentInfo->id][0]['price'],
+                        new FieldType\IntegerField()
+                    ),
+                ],
+            ]),
+            new Document([
+                'id' => uniqid('test_content_translation_subdocument_', false),
+                'fields' => [
+                    new Field(
+                        'document_type',
+                        'test_content_translation_subdocument',
+                        new FieldType\IdentifierField()
+                    ),
+                    new Field(
+                        'visible',
+                        static::$dataMap[$content->versionInfo->contentInfo->id][1]['visible'],
+                        new FieldType\BooleanField()
+                    ),
+                    new Field(
+                        'price',
+                        static::$dataMap[$content->versionInfo->contentInfo->id][1]['price'],
+                        new FieldType\IntegerField()
+                    ),
+                ],
+            ]),
+        ];
+    }
+}

--- a/tests/lib/Resources/config/services.yml
+++ b/tests/lib/Resources/config/services.yml
@@ -1,0 +1,16 @@
+services:
+    netgen_test.search.solr.subdocument_mapper.content:
+        class: Netgen\EzPlatformSearchExtra\Tests\Implementation\Solr\SubdocumentMapper\TestContentSubdocumentMapper
+        tags:
+            - {name: netgen.search.solr.subdocument_mapper.content}
+
+    netgen_test.search.solr.subdocument_mapper.content_translation:
+        class: Netgen\EzPlatformSearchExtra\Tests\Implementation\Solr\SubdocumentMapper\TestContentTranslationSubdocumentMapper
+        tags:
+            - {name: netgen.search.solr.subdocument_mapper.content_translation}
+
+    netgen_test.search.solr.slot.subdocument_publish_version:
+        parent: ezpublish.search.solr.slot
+        class: '%ezpublish.search.solr.slot.publish_version.class%'
+        tags:
+            - {name: ezpublish.search.solr.slot, signal: ContentService\PublishVersionSignal}

--- a/tests/lib/SetupFactory/Solr.php
+++ b/tests/lib/SetupFactory/Solr.php
@@ -3,6 +3,7 @@
 namespace Netgen\EzPlatformSearchExtra\Tests\SetupFactory;
 
 use EzSystems\EzPlatformSolrSearchEngine\Tests\SetupFactory\LegacySetupFactory as CoreSolrSetupFactory;
+use Netgen\EzPlatformSearchExtra\Container\Compiler;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
@@ -16,13 +17,20 @@ class Solr extends CoreSolrSetupFactory
      */
     protected function externalBuildContainer(ContainerBuilder $containerBuilder)
     {
-        $loader = new YamlFileLoader(
-            $containerBuilder,
-            new FileLocator(__DIR__ . '/../../../lib/Resources/config/')
-        );
-
+        $configPath = __DIR__ . '/../../../lib/Resources/config/';
+        $loader = new YamlFileLoader($containerBuilder, new FileLocator($configPath));
+        $loader->load('search/common.yml');
         $loader->load('search/solr.yml');
         $loader->load('persistence.yml');
+
+        $testConfigPath = __DIR__ . '/../Resources/config/';
+        $loader = new YamlFileLoader($containerBuilder, new FileLocator($testConfigPath));
+        $loader->load('services.yml');
+
+        $containerBuilder->addCompilerPass(new Compiler\TagSubdocumentCriterionVisitorsPass());
+        $containerBuilder->addCompilerPass(new Compiler\AggregateContentSubdocumentMapperPass());
+        $containerBuilder->addCompilerPass(new Compiler\AggregateContentTranslationSubdocumentMapperPass());
+        $containerBuilder->addCompilerPass(new Compiler\AggregateSubdocumentQueryCriterionVisitorPass());
 
         parent::externalBuildContainer($containerBuilder);
     }

--- a/tests/lib/SetupFactory/Solr.php
+++ b/tests/lib/SetupFactory/Solr.php
@@ -27,6 +27,7 @@ class Solr extends CoreSolrSetupFactory
         $loader = new YamlFileLoader($containerBuilder, new FileLocator($testConfigPath));
         $loader->load('services.yml');
 
+        // Needs to be added first because other passes depend on it
         $containerBuilder->addCompilerPass(new Compiler\TagSubdocumentCriterionVisitorsPass());
         $containerBuilder->addCompilerPass(new Compiler\AggregateContentSubdocumentMapperPass());
         $containerBuilder->addCompilerPass(new Compiler\AggregateContentTranslationSubdocumentMapperPass());


### PR DESCRIPTION
This feature provides a way to index custom subdocuments under a Content document and a way to define criteria on them using Content search. The feature is available only for Solr search engine.

> **Note**: it isn't possible to search for custom subdocuments directly. Instead, you can define subdocument criteria as a part of Content search, using SubdocumentQuery criterion. Also, relationship between Content and it’s subdocuments is not assumed. These can represent children under it’s main Location, Content relations of a specific ContentType or something else altogether.

## Indexing custom subdocuments

In order to index custom subdocuments, you will need to implement a subdocument mapper plugin. Two extension points are provided, depending on how you want to index subdocuments:

### 1. Indexing custom subdocuments per Content

To index custom subdocuments per Content, implement a service extending `Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentSubdocumentMapper` class, defining two methods:

- `accept(Content $content): bool`

    Here you will receive a Content that is being indexed as an instance of eZ\Publish\SPI\Persistence\Content. Using that object you have to decide whether you want to index custom subdocuments for it or not.

- `map(Content $content): Document`

    Again you will receive an instance of `eZ\Publish\SPI\Persistence\Content`, which you can use to build and return an array of `eZ\Publish\SPI\Search\Document` instances. These represent custom subdocuments that will be indexed under the given Content.

Code example:

```php
final class MyContentSubdocumentMapper extends ContentSubdocumentMapper
{
    public function accept(Content $content)
    {
        return $content->versionInfo->contentInfo->contentTypeId === 42;
    }

    public function mapDocuments(Content $content)
    {
        return [
            new Document([
                'id' => 'unique_id',
                'fields' => [
                    new Field(
                        'document_type',
                        'content_subdocument',
                        new FieldType\IdentifierField()
                    ),
                    new Field('price', 5 new FieldType\IntegerField()),
                ],
            ]),
        ];
    }
}
```

You also have to configure the mapper in the service container configuration, tagging it with `netgen.search.solr.subdocument_mapper.content` tag so that the system can find it.

```yaml
my_content_subdocument_mapper:
    class: MyContentSubdocumentMapper
    tags:
        - {name: netgen.search.solr.subdocument_mapper.content}
```

### 2. Indexing custom subdocuments per Content translation

To index custom subdocuments per Content translation, implement a service extending `Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentTranslationSubdocumentMapper` class, defining two methods:

- `accept(Content $content, string $languageCode): bool`

    Here you will receive a Content being indexed and a language that it’s being indexed in, as an instance of `eZ\Publish\SPI\Persistence\Content` and a language code string. Using these parameters you have to decide whether you want to index custom subdocuments for it or not.

- `map(Content $content, string $languageCode): Document`

    Again you receive an instance of `eZ\Publish\SPI\Persistence\Content` and a language code string. You can use these to build and return an array of `eZ\Publish\SPI\Search\Document` instances, representing custom subdocuments that will be indexed under the given translation of a Content.

Code example:

```php
final class MyContentTranslationSubdocumentMapper extends ContentSubdocumentMapper
{
    public function accept(Content $content, $languageCode)
    {
        $contentTypeId = $content->versionInfo->contentInfo->contentTypeId;

        return $contentTypeId === 42 && $languageCode === 'cro-HR';
    }

    public function mapDocuments(Content $content, $languageCode)
    {
        return [
            new Document([
                'id' => 'unique_subdocument_id',
                'fields' => [
                    new Field(
                        'document_type',
                        'content_translation_subdocument',
                        new FieldType\IdentifierField()
                    ),
                    new Field('price', 5 new FieldType\IntegerField()),
                ],
            ]),
        ];
    }
}
```

You also have to configure the mapper in the service container configuration, tagging it with `netgen.search.solr.subdocument_mapper.content_translation` tag so that the system can find it.

```yaml
my_content_translation_subdocument_mapper:
    class: MyContentTranslationSubdocumentMapper
    tags:
        - {name: netgen.search.solr.subdocument_mapper.content_translation}
```

> **Note**: It’s mandatory to define document_type field of IdentifierField type, in every Document you are returning. You must not use content or location here, since these are already used by the search engine.

## Using custom subdocuments in search

Indexing custom subdocuments would not be very useful without having a way to use them in search. For this SubdocumentQuery criterion is provided. It’s constructor accepts two mandatory arguments:

- `string $documentTypeIdentifier`

    Document type identifier is used to match custom subdocument by it’s type.

- `Criterion $filter`

    Filter is an instance of a criterion, with following of the standard eZ criteria being supported out of the box:

    - `LogicalAnd`
    - `LogicalNot`
    - `LogicalOr`
    - `CustomField`

Code example:

```php
$query = new Query([
    'filter' => new LogicalAnd([
        new ContentTypeIdentifier('product'),
        new SubdocumentQuery(
            'product_variant',
            new LogicalAnd([
                new CustomField('visible_b', Operator::EQ, true),
                new CustomField('price_i', Operator::LT, 40),
            ])
        ),
    ])
]);

$searchResult = $searchService->findContent($query);
```

### Implementing new criteria for SubdocumentQuery

If you want to implement additional criteria to use with SubdocumentQuery just implement is as usual. Then tag the visitor service with `netgen.search.solr.query.content.criterion_visitor.subdocument_query` tag.

### To do
- [x] configure running Repository integration tests to detect regressions
- [x] write description
- [x] setup and write docs