### PR TITLE
Implement SubdocumentField sort clause

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ matrix:
         - php: 7.2
           env: TEST_CONFIG="phpunit-integration-legacy.xml"
         - php: 7.1
-          env: TEST_CONFIG="phpunit-integration-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="single" SOLR_CORES="collection1"
+          env: TEST_CONFIG="phpunit-integration-solr.xml" SOLR_VERSION="6.6.0" CORES_SETUP="single" SOLR_CORES="collection1"
         - php: 7.1
-          env: TEST_CONFIG="phpunit-integration-solr.xml" SOLR_VERSION="6.5.1"  CORES_SETUP="shared" COMPOSER_REQUIRE="ezsystems/ezpublish-kernel:~6.7.4@dev"
+          env: TEST_CONFIG="phpunit-integration-solr.xml" SOLR_VERSION="6.6.0" CORES_SETUP="shared" COMPOSER_REQUIRE="ezsystems/ezpublish-kernel:~6.7.4@dev"
         - php: 7.2
-          env: TEST_CONFIG="phpunit-integration-solr.xml" SOLR_VERSION="6.6.0"  CORES_SETUP="dedicated"
+          env: TEST_CONFIG="phpunit-integration-solr.xml" SOLR_VERSION="6.6.0" CORES_SETUP="dedicated"
         - php: 7.2
           env: TEST_CONFIG="vendor/ezsystems/ezpublish-kernel/phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.6.0" CORES_SETUP="shared" REGRESSION="yes"
 

--- a/README.md
+++ b/README.md
@@ -11,17 +11,22 @@ Only a short list of features is provided here, see
 [documentation](https://netgen-ezplatform-search-extra.readthedocs.io)
 for more details.
 
-- [`IsFieldEmpty`](https://github.com/netgen/ezplatform-search-extra/blob/master/lib/API/Values/Content/Query/Criterion/IsFieldEmpty.php) criterion
+- [`IsFieldEmpty`](https://github.com/netgen/ezplatform-search-extra/blob/master/lib/API/Values/Content/Query/Criterion/IsFieldEmpty.php) criterion (`solr`)
 
   This will work only with Solr search engine and it will require initial reindexing after installation.
 
-- [`ObjectStateIdentifier`](https://github.com/netgen/ezplatform-search-extra/blob/master/lib/API/Values/Content/Query/Criterion/ObjectStateIdentifier.php) criterion
-- [`SectionIdentifier`](https://github.com/netgen/ezplatform-search-extra/blob/master/lib/API/Values/Content/Query/Criterion/SectionIdentifier.php) criterion
-- Support for custom Content subdocuments (Solr search engine)
+- [`ObjectStateIdentifier`](https://github.com/netgen/ezplatform-search-extra/blob/master/lib/API/Values/Content/Query/Criterion/ObjectStateIdentifier.php) criterion (`solr`, `legacy`)
+- [`SectionIdentifier`](https://github.com/netgen/ezplatform-search-extra/blob/master/lib/API/Values/Content/Query/Criterion/SectionIdentifier.php) criterion (`solr`, `legacy`)
+- Support for custom Content subdocuments (Solr search engine) (`solr`)
 
   Provides a way to index custom subdocuments to Content document and
   [`SubdocumentQuery`](https://github.com/netgen/ezplatform-search-extra/blob/master/lib/API/Values/Content/Query/Criterion/SubdocumentQuery.php)
   criterion, available in Content search to define grouped conditions for a custom subdocument.
+
+- [`SubdocumentField`](https://github.com/netgen/ezplatform-search-extra/blob/master/lib/API/Values/Content/Query/SortClause/SubdocumentField.php) sort clause (`solr`)
+
+  Provides a way to sort Content by a subdocument field, choosing scoring calculation mode and optionally limiting with `SubdocumentQuery` criterion.
+  **Note:** This will require Solr `6.6` or higher in order to work correctly with all scoring modes.
 
 ## Installation
 

--- a/lib/API/Values/Content/Query/SortClause/SubdocumentField.php
+++ b/lib/API/Values/Content/Query/SortClause/SubdocumentField.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\API\Values\Content\Query\SortClause;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\SubdocumentQuery;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\SortClause\Target\SubdocumentTarget;
+
+/**
+ * SubdocumentField sort clause is used to sort Content by field in matched subdocument.
+ */
+final class SubdocumentField extends SortClause
+{
+    const ScoringModeNone = 'ScoringModeNone';
+    const ScoringModeAverage = 'ScoringModeAvg';
+    const ScoringModeMaximum = 'ScoringModeMax';
+    const ScoringModeTotal = 'ScoringModeTotal';
+    const ScoringModeMinimum = 'ScoringModeMin';
+
+    /**
+     * @param string $fieldName
+     * @param string $documentTypeIdentifier
+     * @param string $scoringMode
+     * @param string $sortDirection
+     * @param \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\SubdocumentQuery $subdocumentQuery
+     */
+    public function __construct(
+        $fieldName,
+        $documentTypeIdentifier,
+        $scoringMode = self::ScoringModeNone,
+        $sortDirection = Query::SORT_ASC,
+        SubdocumentQuery $subdocumentQuery = null
+    ) {
+        parent::__construct(
+            $fieldName,
+            $sortDirection,
+            new SubdocumentTarget(
+                $documentTypeIdentifier,
+                $scoringMode,
+                $subdocumentQuery
+            )
+        );
+    }
+}

--- a/lib/API/Values/Content/Query/SortClause/Target/SubdocumentTarget.php
+++ b/lib/API/Values/Content/Query/SortClause/Target/SubdocumentTarget.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\API\Values\Content\Query\SortClause\Target;
+
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Target;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\SubdocumentQuery;
+
+final class SubdocumentTarget extends Target
+{
+    /**
+     * Identifier of a targeted Content subdocument.
+     *
+     * @var string
+     */
+    public $documentTypeIdentifier;
+
+    /**
+     * One of the ScoringMode* constants.
+     *
+     * @see \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\SortClause\SubdocumentField
+     *
+     * @var string
+     */
+    public $scoringMode;
+
+    /**
+     * Optional criterion targeting Content subdocument.
+     *
+     * @var \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\SubdocumentQuery
+     */
+    public $subdocumentQuery;
+
+    /**
+     * @param string $documentTypeIdentifier
+     * @param string $scoringMode
+     * @param \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\SubdocumentQuery $subdocumentQuery
+     */
+    public function __construct($documentTypeIdentifier, $scoringMode, SubdocumentQuery $subdocumentQuery = null)
+    {
+        $this->documentTypeIdentifier = $documentTypeIdentifier;
+        $this->scoringMode = $scoringMode;
+        $this->subdocumentQuery = $subdocumentQuery;
+    }
+}

--- a/lib/Core/Search/Solr/Query/Content/SortClauseVisitor/SubdocumentField.php
+++ b/lib/Core/Search/Solr/Query/Content/SortClauseVisitor/SubdocumentField.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Content\SortClauseVisitor;
+
+use EzSystems\EzPlatformSolrSearchEngine\Query\SortClauseVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\SubdocumentQuery;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\SortClause\SubdocumentField as SubdocumentFieldCriterion;
+use RuntimeException;
+
+class SubdocumentField extends SortClauseVisitor
+{
+    /**
+     * @var \EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor
+     */
+    private $subdocumentQueryCriterionVisitor;
+
+    /**
+     * @param \EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor $subdocumentQueryCriterionVisitor
+     */
+    public function __construct(CriterionVisitor $subdocumentQueryCriterionVisitor)
+    {
+        $this->subdocumentQueryCriterionVisitor = $subdocumentQueryCriterionVisitor;
+    }
+
+    public function canVisit(SortClause $sortClause)
+    {
+        return $sortClause instanceof SubdocumentFieldCriterion;
+    }
+
+    public function visit(SortClause $sortClause)
+    {
+        /** @var \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\SortClause\Target\SubdocumentTarget $target */
+        $target = $sortClause->targetData;
+        $condition = "document_type_id:{$target->documentTypeIdentifier}";
+
+        if ($target->subdocumentQuery instanceof SubdocumentQuery) {
+            /** @var \eZ\Publish\API\Repository\Values\Content\Query\Criterion $filter */
+            $filter = $target->subdocumentQuery->value;
+            $queryCondition = $this->subdocumentQueryCriterionVisitor->visit($filter);
+            $queryCondition = $this->escapeQuote($queryCondition);
+
+            $condition .= ' AND ' . $queryCondition;
+        }
+
+        $condition .= " AND {!func}{$sortClause->target}";
+        $scoringMode = $this->resolveScoringMode($target->scoringMode);
+
+        return "{!parent which='document_type_id:content' score='{$scoringMode}' v='{$condition}'}" . $this->getDirection($sortClause);
+    }
+
+    private function resolveScoringMode($mode)
+    {
+        switch ($mode) {
+            case SubdocumentFieldCriterion::ScoringModeNone:
+                return 'none';
+            case SubdocumentFieldCriterion::ScoringModeAverage:
+                return 'avg';
+            case SubdocumentFieldCriterion::ScoringModeMaximum:
+                return 'max';
+            case SubdocumentFieldCriterion::ScoringModeTotal:
+                return 'total';
+            case SubdocumentFieldCriterion::ScoringModeMinimum:
+                return 'min';
+        }
+
+        throw new RuntimeException(
+            "Scoring mode '{$mode}' is not handled"
+        );
+    }
+
+    /**
+     * Escapes given $string for wrapping inside single or double quotes.
+     *
+     * Does not include quotes in the returned string, this needs to be done by the consumer code.
+     *
+     * @param string $string
+     * @param bool $doubleQuote
+     *
+     * @return string
+     */
+    private function escapeQuote($string, $doubleQuote = false)
+    {
+        $pattern = ($doubleQuote ? '/("|\\\)/' : '/(\'|\\\)/');
+
+        return preg_replace($pattern, '\\\$1', $string);
+    }
+}

--- a/lib/Resources/config/search/solr.yml
+++ b/lib/Resources/config/search/solr.yml
@@ -2,6 +2,7 @@ imports:
     - {resource: solr/criterion_visitors.yml}
     - {resource: solr/facet_builder_visitors.yml}
     - {resource: solr/field_mappers.yml}
+    - {resource: solr/sort_clause_visitors.yml}
     - {resource: solr/subdocument_mappers.yml}
 
 services:

--- a/lib/Resources/config/search/solr/sort_clause_visitors.yml
+++ b/lib/Resources/config/search/solr/sort_clause_visitors.yml
@@ -1,0 +1,7 @@
+services:
+    netgen.search.solr.query.content.sort_clause_visitor.subdocument_field:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Content\SortClauseVisitor\SubdocumentField
+        arguments:
+            - '@netgen.search.solr.query.content.criterion_visitor.subdocument_query.aggregate'
+        tags:
+            - {name: ezpublish.search.solr.query.content.sort_clause_visitor}

--- a/phpunit-integration-legacy.xml
+++ b/phpunit-integration-legacy.xml
@@ -14,6 +14,7 @@
             <!-- Exclude tests not supported with Legacy search engine -->
             <exclude>tests/lib/API/CustomFieldFacetTest.php</exclude>
             <exclude>tests/lib/API/IsFieldEmptyCriterionTest.php</exclude>
+            <exclude>tests/lib/API/SubdocumentFieldSortClauseTest.php</exclude>
             <exclude>tests/lib/API/SubdocumentQueryCriterionTest.php</exclude>
         </testsuite>
     </testsuites>

--- a/tests/lib/API/SubdocumentFieldSortClauseTest.php
+++ b/tests/lib/API/SubdocumentFieldSortClauseTest.php
@@ -1,0 +1,365 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Tests\API;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentId;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\CustomField;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentId as ContentIdSortClause;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\SubdocumentQuery;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\SortClause\SubdocumentField;
+
+/**
+ * @see \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\SortClause\SubdocumentField
+ */
+class SubdocumentFieldSortClauseTest extends BaseTest
+{
+    public function providerForTestSort()
+    {
+        $documentTypeIdentifier = 'test_sort_content_subdocument';
+
+        return [
+            [
+                new Query([
+                    'filter' => new ContentId([12, 42, 59, 4]),
+                    'sortClauses' => [
+                        new SubdocumentField(
+                            'price_i',
+                            $documentTypeIdentifier,
+                            SubdocumentField::ScoringModeMaximum,
+                            Query::SORT_ASC
+                        ),
+                    ],
+                ]),
+                [4, 59, 12, 42],
+            ],
+            [
+                new Query([
+                    'filter' => new ContentId([12, 42, 59, 4]),
+                    'sortClauses' => [
+                        new SubdocumentField(
+                            'price_i',
+                            $documentTypeIdentifier,
+                            SubdocumentField::ScoringModeMaximum,
+                            Query::SORT_DESC
+                        ),
+                    ],
+                ]),
+                [42, 12, 59, 4],
+            ],
+            [
+                new Query([
+                    'filter' => new ContentId([12, 42, 59, 4]),
+                    'sortClauses' => [
+                        new SubdocumentField(
+                            'price_i',
+                            $documentTypeIdentifier,
+                            SubdocumentField::ScoringModeMinimum,
+                            Query::SORT_ASC
+                        ),
+                    ],
+                ]),
+                [4, 42, 12, 59],
+            ],
+            [
+                new Query([
+                    'filter' => new ContentId([12, 42, 59, 4]),
+                    'sortClauses' => [
+                        new SubdocumentField(
+                            'price_i',
+                            $documentTypeIdentifier,
+                            SubdocumentField::ScoringModeMinimum,
+                            Query::SORT_DESC
+                        ),
+                    ],
+                ]),
+                [59, 12, 42, 4],
+            ],
+            [
+                new Query([
+                    'filter' => new ContentId([12, 42, 59, 4]),
+                    'sortClauses' => [
+                        new SubdocumentField(
+                            'price_i',
+                            $documentTypeIdentifier,
+                            SubdocumentField::ScoringModeTotal,
+                            Query::SORT_ASC
+                        ),
+                    ],
+                ]),
+                [4, 12, 59, 42],
+            ],
+            [
+                new Query([
+                    'filter' => new ContentId([12, 42, 59, 4]),
+                    'sortClauses' => [
+                        new SubdocumentField(
+                            'price_i',
+                            $documentTypeIdentifier,
+                            SubdocumentField::ScoringModeTotal,
+                            Query::SORT_DESC
+                        ),
+                    ],
+                ]),
+                [42, 59, 12, 4],
+            ],
+            [
+                new Query([
+                    'filter' => new ContentId([12, 42, 59, 4]),
+                    'sortClauses' => [
+                        new SubdocumentField(
+                            'price_i',
+                            $documentTypeIdentifier,
+                            SubdocumentField::ScoringModeAverage,
+                            Query::SORT_ASC
+                        ),
+                    ],
+                ]),
+                [4, 12, 59, 42],
+            ],
+            [
+                new Query([
+                    'filter' => new ContentId([12, 42, 59, 4]),
+                    'sortClauses' => [
+                        new SubdocumentField(
+                            'price_i',
+                            $documentTypeIdentifier,
+                            SubdocumentField::ScoringModeAverage,
+                            Query::SORT_DESC
+                        ),
+                    ],
+                ]),
+                [42, 59, 12, 4],
+            ],
+            [
+                new Query([
+                    'filter' => new ContentId([12, 42, 59, 4]),
+                    'sortClauses' => [
+                        new SubdocumentField(
+                            'price_i',
+                            $documentTypeIdentifier,
+                            SubdocumentField::ScoringModeNone,
+                            Query::SORT_ASC
+                        ),
+                        new ContentIdSortClause(Query::SORT_ASC),
+                    ],
+                ]),
+                [12, 4, 42, 59],
+            ],
+            [
+                new Query([
+                    'filter' => new ContentId([12, 42, 59, 4]),
+                    'sortClauses' => [
+                        new SubdocumentField(
+                            'price_i',
+                            $documentTypeIdentifier,
+                            SubdocumentField::ScoringModeNone,
+                            Query::SORT_DESC
+                        ),
+                        new ContentIdSortClause(Query::SORT_DESC),
+                    ],
+                ]),
+                [59, 42, 4, 12],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForTestSort
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     * @param array $expectedIds
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testSortContent(Query $query, array $expectedIds)
+    {
+        $searchService = $this->getSearchService(true);
+
+        $searchResult = $searchService->findContentInfo($query);
+
+        $this->assertSearchResultContentIds($searchResult, $expectedIds);
+    }
+
+    public function providerForTestFilteredSort()
+    {
+        $documentTypeIdentifier = 'test_sort_content_subdocument';
+        $filter = new SubdocumentQuery(
+            'test_sort_content_subdocument',
+            new CustomField('price_i', Operator::LT, 20)
+        );
+
+        return [
+            [
+                new Query([
+                    'filter' => new ContentId([12, 42, 59, 4]),
+                    'sortClauses' => [
+                        new SubdocumentField(
+                            'price_i',
+                            $documentTypeIdentifier,
+                            SubdocumentField::ScoringModeMaximum,
+                            Query::SORT_ASC,
+                            $filter
+                        ),
+                    ],
+                ]),
+                [4, 42, 12, 59],
+            ],
+            [
+                new Query([
+                    'filter' => new ContentId([12, 42, 59, 4]),
+                    'sortClauses' => [
+                        new SubdocumentField(
+                            'price_i',
+                            $documentTypeIdentifier,
+                            SubdocumentField::ScoringModeMaximum,
+                            Query::SORT_DESC,
+                            $filter
+                        ),
+                    ],
+                ]),
+                [59, 12, 42, 4],
+            ],
+            [
+                new Query([
+                    'filter' => new ContentId([12, 42, 59, 4]),
+                    'sortClauses' => [
+                        new SubdocumentField(
+                            'price_i',
+                            $documentTypeIdentifier,
+                            SubdocumentField::ScoringModeMinimum,
+                            Query::SORT_ASC,
+                            $filter
+                        ),
+                    ],
+                ]),
+                [4, 42, 12, 59],
+            ],
+            [
+                new Query([
+                    'filter' => new ContentId([12, 42, 59, 4]),
+                    'sortClauses' => [
+                        new SubdocumentField(
+                            'price_i',
+                            $documentTypeIdentifier,
+                            SubdocumentField::ScoringModeMinimum,
+                            Query::SORT_DESC,
+                            $filter
+                        ),
+                    ],
+                ]),
+                [59, 12, 42, 4],
+            ],
+            [
+                new Query([
+                    'filter' => new ContentId([12, 42, 59, 4]),
+                    'sortClauses' => [
+                        new SubdocumentField(
+                            'price_i',
+                            $documentTypeIdentifier,
+                            SubdocumentField::ScoringModeTotal,
+                            Query::SORT_ASC,
+                            $filter
+                        ),
+                    ],
+                ]),
+                [4, 42, 12, 59],
+            ],
+            [
+                new Query([
+                    'filter' => new ContentId([12, 42, 59, 4]),
+                    'sortClauses' => [
+                        new SubdocumentField(
+                            'price_i',
+                            $documentTypeIdentifier,
+                            SubdocumentField::ScoringModeTotal,
+                            Query::SORT_DESC,
+                            $filter
+                        ),
+                    ],
+                ]),
+                [59, 12, 42, 4],
+            ],
+            [
+                new Query([
+                    'filter' => new ContentId([12, 42, 59, 4]),
+                    'sortClauses' => [
+                        new SubdocumentField(
+                            'price_i',
+                            $documentTypeIdentifier,
+                            SubdocumentField::ScoringModeAverage,
+                            Query::SORT_ASC,
+                            $filter
+                        ),
+                    ],
+                ]),
+                [4, 42, 12, 59],
+            ],
+            [
+                new Query([
+                    'filter' => new ContentId([12, 42, 59, 4]),
+                    'sortClauses' => [
+                        new SubdocumentField(
+                            'price_i',
+                            $documentTypeIdentifier,
+                            SubdocumentField::ScoringModeAverage,
+                            Query::SORT_DESC,
+                            $filter
+                        ),
+                    ],
+                ]),
+                [59, 12, 42, 4],
+            ],
+            [
+                new Query([
+                    'filter' => new ContentId([12, 42, 59, 4]),
+                    'sortClauses' => [
+                        new SubdocumentField(
+                            'price_i',
+                            $documentTypeIdentifier,
+                            SubdocumentField::ScoringModeNone,
+                            Query::SORT_ASC,
+                            $filter
+                        ),
+                        new ContentIdSortClause(Query::SORT_ASC),
+                    ],
+                ]),
+                [12, 4, 42, 59],
+            ],
+            [
+                new Query([
+                    'filter' => new ContentId([12, 42, 59, 4]),
+                    'sortClauses' => [
+                        new SubdocumentField(
+                            'price_i',
+                            $documentTypeIdentifier,
+                            SubdocumentField::ScoringModeNone,
+                            Query::SORT_DESC,
+                            $filter
+                        ),
+                        new ContentIdSortClause(Query::SORT_DESC),
+                    ],
+                ]),
+                [59, 42, 4, 12],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForTestFilteredSort
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     * @param array $expectedIds
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testFilteredSortContent(Query $query, array $expectedIds)
+    {
+        $searchService = $this->getSearchService(true);
+
+        $searchResult = $searchService->findContentInfo($query);
+
+        $this->assertSearchResultContentIds($searchResult, $expectedIds);
+    }
+}

--- a/tests/lib/API/SubdocumentQueryCriterionTest.php
+++ b/tests/lib/API/SubdocumentQueryCriterionTest.php
@@ -250,14 +250,6 @@ class SubdocumentQueryCriterionTest extends BaseTest
         $repository = $this->getRepository();
         $contentService = $repository->getContentService();
 
-        $contentInfo = $contentService->loadContentInfo(10);
-        $draft = $contentService->createContentDraft($contentInfo);
-        $contentService->publishVersion($draft->versionInfo);
-
-        $contentInfo = $contentService->loadContentInfo(14);
-        $draft = $contentService->createContentDraft($contentInfo);
-        $contentService->publishVersion($draft->versionInfo);
-
         $contentInfo = $contentService->loadContentInfo(4);
         $draft = $contentService->createContentDraft($contentInfo);
         $updateStruct = $contentService->newContentUpdateStruct();

--- a/tests/lib/Implementation/Solr/SubdocumentMapper/TestSortContentSubdocumentMapper.php
+++ b/tests/lib/Implementation/Solr/SubdocumentMapper/TestSortContentSubdocumentMapper.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Tests\Implementation\Solr\SubdocumentMapper;
+
+use eZ\Publish\SPI\Persistence\Content;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType;
+use eZ\Publish\SPI\Search\Document;
+use Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentSubdocumentMapper;
+
+/**
+ * Note: here we  are only simulating indexing children data.
+ */
+class TestSortContentSubdocumentMapper extends ContentSubdocumentMapper
+{
+    static private $dataMap = [
+        // Administrator Users
+        '12' => [
+            0 => [
+                'price' => 5,
+            ],
+            1 => [
+                'price' => 5,
+            ],
+            2 => [
+                'price' => 35,
+            ],
+        ],
+        // Anonymous Users
+        '42' => [
+            0 => [
+                'price' => 4,
+            ],
+            1 => [
+                'price' => 500,
+            ],
+            2 => [
+                'price' => 60,
+            ]
+        ],
+        // Partners
+        '59' => [
+            0 => [
+                'price' => 10,
+            ],
+            1 => [
+                'price' => 10,
+            ],
+            2 => [
+                'price' => 20,
+            ],
+            3 => [
+                'price' => 30,
+            ],
+        ],
+    ];
+
+    public function accept(Content $content)
+    {
+        return array_key_exists($content->versionInfo->contentInfo->id, static::$dataMap);
+    }
+
+    public function mapDocuments(Content $content)
+    {
+        $documents = [];
+
+        foreach (static::$dataMap[$content->versionInfo->contentInfo->id] as $data) {
+            $documents[] = new Document([
+                'id' => uniqid('test_content_subdocument_', false),
+                'fields' => [
+                    new Field(
+                        'document_type',
+                        'test_sort_content_subdocument',
+                        new FieldType\IdentifierField()
+                    ),
+                    new Field(
+                        'price',
+                        $data['price'],
+                        new FieldType\IntegerField()
+                    ),
+                ],
+            ]);
+        }
+
+        return $documents;
+    }
+}

--- a/tests/lib/Resources/config/services.yml
+++ b/tests/lib/Resources/config/services.yml
@@ -9,6 +9,11 @@ services:
         tags:
             - {name: netgen.search.solr.subdocument_mapper.content_translation}
 
+    netgen_test.search.solr.subdocument_mapper.content.sort:
+        class: Netgen\EzPlatformSearchExtra\Tests\Implementation\Solr\SubdocumentMapper\TestSortContentSubdocumentMapper
+        tags:
+            - {name: netgen.search.solr.subdocument_mapper.content}
+
     netgen_test.search.solr.slot.subdocument_publish_version:
         parent: ezpublish.search.solr.slot
         class: '%ezpublish.search.solr.slot.publish_version.class%'


### PR DESCRIPTION
Related PR: https://github.com/netgen/ezplatform-search-extra/pull/3

This implements `SubdocumentField` sort clause, which enables sorting Content by field from a subdocument. Following sorting score calculating modes are supported:

- none
- minimum
- maximum
- total
- average

Sort clause can optionally accept `SubdocumentQuery`, which is used to filter subdocuments that are used in sorting score calculation.

Example usage:

```php
new Query([
    'filter' => new ContentId([12, 42, 59, 4]),
    'sortClauses' => [
        new SubdocumentField(
            'price_i',
            'test_sort_content_subdocument',
            SubdocumentField::ScoringModeMaximum,
            Query::SORT_ASC,
            new SubdocumentQuery(
                'test_sort_content_subdocument',
                new CustomField('price_i', Operator::LT, 20)
            )
        ),
    ],
]);
```