### PR TITLE
Implement loading search result extractor with configuration

### DIFF
--- a/bundle/DependencyInjection/Configuration.php
+++ b/bundle/DependencyInjection/Configuration.php
@@ -69,9 +69,9 @@ class Configuration implements ConfigurationInterface
     {
         $nodeDefinition
             ->children()
-                ->booleanNode('use_native_search_result_extractor')
-                    ->info('Get search result objects by reconstructing them from the returned Solr data, instead of loading them from the persistence layer')
-                    ->defaultFalse()
+                ->booleanNode('use_loading_search_result_extractor')
+                    ->info('Get search result objects by loading them from the persistence layer, instead of reconstructing them from the returned Solr data')
+                    ->defaultTrue()
                 ->end()
             ->end();
     }

--- a/bundle/DependencyInjection/Configuration.php
+++ b/bundle/DependencyInjection/Configuration.php
@@ -27,6 +27,7 @@ class Configuration implements ConfigurationInterface
         $rootNode = $treeBuilder->root($this->rootNodeName);
 
         $this->addIndexableFieldTypeSection($rootNode);
+        $this->addSearchResultExtractorSection($rootNode);
 
         return $treeBuilder;
     }
@@ -60,6 +61,17 @@ class Configuration implements ConfigurationInterface
                             ->end()
                         ->end()
                     ->end()
+                ->end()
+            ->end();
+    }
+
+    private function addSearchResultExtractorSection(ArrayNodeDefinition $nodeDefinition)
+    {
+        $nodeDefinition
+            ->children()
+                ->booleanNode('use_native_search_result_extractor')
+                    ->info('Get search result objects by reconstructing them from the returned Solr data, instead of loading them from the persistence layer')
+                    ->defaultFalse()
                 ->end()
             ->end();
     }

--- a/bundle/DependencyInjection/NetgenEzPlatformSearchExtraExtension.php
+++ b/bundle/DependencyInjection/NetgenEzPlatformSearchExtraExtension.php
@@ -65,8 +65,8 @@ class NetgenEzPlatformSearchExtraExtension extends Extension
     private function processSearchResultExtractorConfiguration(array $configuration, ContainerBuilder $container)
     {
         $container->setParameter(
-            'netgen_ez_platform_search_extra.use_native_search_result_extractor',
-            $configuration['use_native_search_result_extractor']
+            'netgen_ez_platform_search_extra.use_loading_search_result_extractor',
+            $configuration['use_loading_search_result_extractor']
         );
     }
 

--- a/bundle/DependencyInjection/NetgenEzPlatformSearchExtraExtension.php
+++ b/bundle/DependencyInjection/NetgenEzPlatformSearchExtraExtension.php
@@ -58,6 +58,20 @@ class NetgenEzPlatformSearchExtraExtension extends Extension
 
         $configuration = $this->processConfiguration($configuration, $configs);
 
+        $this->processIndexableFieldTypeConfiguration($configuration, $container);
+        $this->processSearchResultExtractorConfiguration($configuration, $container);
+    }
+
+    private function processSearchResultExtractorConfiguration(array $configuration, ContainerBuilder $container)
+    {
+        $container->setParameter(
+            'netgen_ez_platform_search_extra.use_native_search_result_extractor',
+            $configuration['use_native_search_result_extractor']
+        );
+    }
+
+    private function processIndexableFieldTypeConfiguration(array $configuration, ContainerBuilder $container)
+    {
         $container->setParameter(
             'netgen_ez_platform_search_extra.indexable_field_type.ezrichtext.enabled',
             $configuration['indexable_field_type']['ezrichtext']['enabled']

--- a/bundle/NetgenEzPlatformSearchExtraBundle.php
+++ b/bundle/NetgenEzPlatformSearchExtraBundle.php
@@ -20,5 +20,6 @@ class NetgenEzPlatformSearchExtraBundle extends Bundle
         $containerBuilder->addCompilerPass(new Compiler\AggregateSubdocumentQueryCriterionVisitorPass());
         $containerBuilder->addCompilerPass(new Compiler\FieldType\RichTextIndexablePass());
         $containerBuilder->addCompilerPass(new Compiler\FieldType\XmlTextIndexablePass());
+        $containerBuilder->addCompilerPass(new Compiler\SearchResultExtractorPass());
     }
 }

--- a/lib/Container/Compiler/SearchResultExtractorPass.php
+++ b/lib/Container/Compiler/SearchResultExtractorPass.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Container\Compiler;
+
+use Netgen\EzPlatformSearchExtra\Core\Search\Solr\ResultExtractor\NativeResultExtractor;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Configures native search result extractor if the loading search result extractor is disabled.
+ *
+ * @see \Netgen\EzPlatformSearchExtra\Core\Search\Solr\ResultExtractor\NativeResultExtractor
+ */
+final class SearchResultExtractorPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Exception
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $useNativeSearchResultExtractor = $container->getParameter(
+            'netgen_ez_platform_search_extra.use_native_search_result_extractor'
+        );
+
+        if ($useNativeSearchResultExtractor !== true) {
+            return;
+        }
+
+        $serviceId = 'netgen.search.solr.result_extractor.native_override';
+        $decoratedServiceId = 'ezpublish.search.solr.result_extractor.native';
+
+        $container
+            ->register($serviceId, NativeResultExtractor::class)
+            ->setDecoratedService($decoratedServiceId)
+            ->setArguments([
+                new Reference($serviceId . '.inner'),
+                new Reference('ezpublish.search.solr.query.content.facet_builder_visitor.aggregate'),
+                new Reference('ezpublish.search.solr.gateway.endpoint_registry'),
+            ]);
+    }
+}

--- a/lib/Container/Compiler/SearchResultExtractorPass.php
+++ b/lib/Container/Compiler/SearchResultExtractorPass.php
@@ -22,11 +22,11 @@ final class SearchResultExtractorPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $useNativeSearchResultExtractor = $container->getParameter(
-            'netgen_ez_platform_search_extra.use_native_search_result_extractor'
+        $useLoadingSearchResultExtractor = $container->getParameter(
+            'netgen_ez_platform_search_extra.use_loading_search_result_extractor'
         );
 
-        if ($useNativeSearchResultExtractor !== true) {
+        if ($useLoadingSearchResultExtractor === true) {
             return;
         }
 

--- a/lib/Core/Search/Solr/Handler.php
+++ b/lib/Core/Search/Solr/Handler.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalNot;
+use EzSystems\EzPlatformSolrSearchEngine\Handler as BaseHandler;
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+
+class Handler extends BaseHandler
+{
+    protected function deleteAllItemsWithoutAdditionalLocation($locationId)
+    {
+        $query = $this->prepareQuery();
+        $query->filter = new LogicalAnd([
+            $this->allItemsWithinLocation($locationId),
+            new LogicalNot($this->allItemsWithinLocationWithAdditionalLocation($locationId)),
+        ]);
+
+        $contentIds = $this->extractContentIds(
+            $this->gateway->searchAllEndpoints($query)
+        );
+
+        foreach ($contentIds as $contentId) {
+            $idPrefix = $this->mapper->generateContentDocumentId($contentId);
+            $this->gateway->deleteByQuery("_root_:{$idPrefix}*");
+        }
+    }
+
+    protected function updateAllElementsWithAdditionalLocation($locationId)
+    {
+        $query = $this->prepareQuery();
+        $query->filter = new LogicalAnd([
+            $this->allItemsWithinLocation($locationId),
+            $this->allItemsWithinLocationWithAdditionalLocation($locationId),
+        ]);
+
+        $contentIds = $this->extractContentIds(
+            $this->gateway->searchAllEndpoints($query)
+        );
+
+        $contentItems = [];
+        foreach ($contentIds as $contentId) {
+            try {
+                $contentInfo = $this->contentHandler->loadContentInfo($contentId);
+            } catch (NotFoundException $e) {
+                continue;
+            }
+
+            $contentItems[] = $this->contentHandler->load(
+                $contentInfo->id,
+                $contentInfo->currentVersionNo
+            );
+        }
+
+        $this->bulkIndexContent($contentItems);
+    }
+
+    /**
+     * @param mixed $data
+     *
+     * @return array
+     */
+    private function extractContentIds($data)
+    {
+        $ids = [];
+
+        foreach ($data->response->docs as $doc) {
+            $ids[] = $doc->content_id_id;
+        }
+
+        return $ids;
+    }
+}

--- a/lib/Core/Search/Solr/ResultExtractor.php
+++ b/lib/Core/Search/Solr/ResultExtractor.php
@@ -2,7 +2,6 @@
 
 namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr;
 
-use EzSystems\EzPlatformSolrSearchEngine\Query\FacetFieldVisitor;
 use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor as BaseResultExtractor;
 use Netgen\EzPlatformSearchExtra\Core\Search\Solr\API\FacetBuilder\RawFacetBuilder;
 
@@ -11,30 +10,11 @@ use Netgen\EzPlatformSearchExtra\Core\Search\Solr\API\FacetBuilder\RawFacetBuild
  *
  * @see \Netgen\EzPlatformSearchExtra\Core\Search\Solr\API\Facet\RawFacetBuilder
  */
-final class ResultExtractor Extends BaseResultExtractor
+abstract class ResultExtractor Extends BaseResultExtractor
 {
-    /**
-     * @var \EzSystems\EzPlatformSolrSearchEngine\ResultExtractor
-     */
-    private $nativeResultExtractor;
-
-    /** @noinspection PhpMissingParentConstructorInspection */
-    /** @noinspection MagicMethodsValidityInspection */
-    /**
-     * @param \EzSystems\EzPlatformSolrSearchEngine\ResultExtractor $nativeResultExtractor
-     * @param \EzSystems\EzPlatformSolrSearchEngine\Query\FacetFieldVisitor $facetBuilderVisitor
-     */
-    public function __construct(
-        BaseResultExtractor $nativeResultExtractor,
-        FacetFieldVisitor $facetBuilderVisitor
-    ) {
-        $this->nativeResultExtractor = $nativeResultExtractor;
-        $this->facetBuilderVisitor = $facetBuilderVisitor;
-    }
-
     public function extract($data, array $facetBuilders = [])
     {
-        $searchResult = $this->nativeResultExtractor->extract($data, $facetBuilders);
+        $searchResult = $this->extractSearchResult($data, $facetBuilders);
 
         if (!isset($data->facets) || $data->facets->count === 0) {
             return $searchResult;
@@ -54,6 +34,16 @@ final class ResultExtractor Extends BaseResultExtractor
     }
 
     /**
+     * Extract the base search result.
+     *
+     * @param mixed $data
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder[] $facetBuilders
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
+     */
+    abstract protected function extractSearchResult($data, array $facetBuilders = []);
+
+    /**
      * @param \eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder[] $facetBuilders
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder[]
@@ -66,10 +56,5 @@ final class ResultExtractor Extends BaseResultExtractor
                 return $facetBuilder instanceof RawFacetBuilder;
             }
         );
-    }
-
-    public function extractHit($hit)
-    {
-        return $this->nativeResultExtractor->extractHit($hit);
     }
 }

--- a/lib/Core/Search/Solr/ResultExtractor/LoadingResultExtractor.php
+++ b/lib/Core/Search/Solr/ResultExtractor/LoadingResultExtractor.php
@@ -66,8 +66,6 @@ final class LoadingResultExtractor Extends ResultExtractor
     /**
      * @param \eZ\Publish\API\Repository\Values\Content\Search\SearchResult $searchResult
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
-     *
      * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
      */
     private function replaceExtractedValuesByLoadedValues(SearchResult $searchResult)
@@ -89,8 +87,6 @@ final class LoadingResultExtractor Extends ResultExtractor
 
     /**
      * @param \eZ\Publish\API\Repository\Values\Content\Search\SearchResult $searchResult
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      *
      * @return array|\eZ\Publish\SPI\Persistence\Content\ContentInfo[]
      */

--- a/lib/Core/Search/Solr/ResultExtractor/LoadingResultExtractor.php
+++ b/lib/Core/Search/Solr/ResultExtractor/LoadingResultExtractor.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\ResultExtractor;
+
+use eZ\Publish\SPI\Persistence\Content\ContentInfo;
+use eZ\Publish\SPI\Persistence\Content\Location;
+use EzSystems\EzPlatformSolrSearchEngine\Gateway\EndpointRegistry;
+use EzSystems\EzPlatformSolrSearchEngine\Query\FacetFieldVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor as BaseResultExtractor;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+use eZ\Publish\SPI\Persistence\Content\Handler as ContentHandler;
+use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandler;
+use Netgen\EzPlatformSearchExtra\Core\Search\Solr\ResultExtractor;
+use RuntimeException;
+
+/**
+ * The Loading Result Extractor extracts the value object from the Solr search hit data
+ * by loading it from the persistence layer.
+ */
+final class LoadingResultExtractor Extends ResultExtractor
+{
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Handler
+     */
+    protected $contentHandler;
+
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Location\Handler
+     */
+    protected $locationHandler;
+
+    /**
+     * @var \EzSystems\EzPlatformSolrSearchEngine\ResultExtractor
+     */
+    private $nativeResultExtractor;
+
+    public function __construct(
+        ContentHandler $contentHandler,
+        LocationHandler $locationHandler,
+        BaseResultExtractor $nativeResultExtractor,
+        FacetFieldVisitor $facetBuilderVisitor,
+        EndpointRegistry $endpointRegistry
+    ) {
+        $this->contentHandler = $contentHandler;
+        $this->locationHandler = $locationHandler;
+        $this->nativeResultExtractor = $nativeResultExtractor;
+
+        parent::__construct($facetBuilderVisitor, $endpointRegistry);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    protected function extractSearchResult($data, array $facetBuilders = [])
+    {
+        $searchResult = $this->nativeResultExtractor->extract($data, $facetBuilders);
+
+        $this->replaceExtractedValuesByLoadedValues($searchResult);
+
+        return $searchResult;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Search\SearchResult $searchResult
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
+     */
+    private function replaceExtractedValuesByLoadedValues(SearchResult $searchResult)
+    {
+        $valueObjectMapById = $this->loadValueObjectMapById($searchResult);
+
+        foreach ($searchResult->searchHits as $searchHit) {
+            $searchHit->valueObject = $valueObjectMapById[$this->getValueObjectId($searchHit->valueObject)];
+        }
+
+        return $searchResult;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Search\SearchResult $searchResult
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     *
+     * @return array|\eZ\Publish\SPI\Persistence\Content\ContentInfo[]
+     */
+    private function loadValueObjectMapById(SearchResult $searchResult)
+    {
+        if (!isset($searchResult->searchHits[0])) {
+            return [];
+        }
+
+        $idList = $this->extractIdList($searchResult);
+
+        if ($searchResult->searchHits[0]->valueObject instanceof ContentInfo) {
+            return $this->loadContentInfoMapByIdList($idList);
+        }
+
+        return $this->loadLocationMapByIdList($idList);
+    }
+
+    private function extractIdList(SearchResult $searchResult)
+    {
+        $idList = [];
+
+        foreach ($searchResult->searchHits as $searchHit) {
+            $idList[] = $this->getValueObjectId($searchHit->valueObject);
+        }
+
+        return $idList;
+    }
+
+    private function getValueObjectId($valueObject)
+    {
+        if ($valueObject instanceof ContentInfo) {
+            return $valueObject->id;
+        }
+
+        if ($valueObject instanceof Location) {
+            return $valueObject->id;
+        }
+
+        throw new RuntimeException("Couldn't handle given value object.");
+    }
+
+    private function loadContentInfoMapByIdList(array $contentIdList)
+    {
+        if (method_exists($this->contentHandler, 'loadContentInfoList')) {
+            return $this->contentHandler->loadContentInfoList($contentIdList);
+        }
+
+        $contentInfoList = [];
+
+        foreach ($contentIdList as $contentId) {
+            $contentInfoList[$contentId] = $this->contentHandler->loadContentInfo($contentId);
+        }
+
+        return $contentInfoList;
+    }
+
+    /**
+     * @param array $locationIdList
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     *
+     * @return array|\eZ\Publish\SPI\Persistence\Content\ContentInfo[]
+     */
+    private function loadLocationMapByIdList(array $locationIdList)
+    {
+        if (method_exists($this->locationHandler, 'loadList')) {
+            return $this->locationHandler->loadList($locationIdList);
+        }
+
+        $locationList = [];
+
+        foreach ($locationIdList as $locationId) {
+            $locationList[$locationId] = $this->locationHandler->load($locationId);
+        }
+
+        return $locationList;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \RuntimeException If search $hit could not be handled
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function extractHit($hit)
+    {
+        if ($hit->document_type_id === 'content') {
+            return $this->contentHandler->loadContentInfo($hit->content_id_id);
+        }
+
+        if ($hit->document_type_id === 'location') {
+            return $this->locationHandler->load($hit->location_id_id);
+        }
+
+        throw new RuntimeException(
+            "Extracting documents of type '{$hit->document_type_id}' is not handled."
+        );
+    }
+}

--- a/lib/Core/Search/Solr/ResultExtractor/LoadingResultExtractor.php
+++ b/lib/Core/Search/Solr/ResultExtractor/LoadingResultExtractor.php
@@ -49,11 +49,6 @@ final class LoadingResultExtractor Extends ResultExtractor
         parent::__construct($facetBuilderVisitor, $endpointRegistry);
     }
 
-    /**
-     * {@inheritdoc}
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
-     */
     protected function extractSearchResult($data, array $facetBuilders = [])
     {
         $searchResult = $this->nativeResultExtractor->extract($data, $facetBuilders);

--- a/lib/Core/Search/Solr/ResultExtractor/LoadingResultExtractor.php
+++ b/lib/Core/Search/Solr/ResultExtractor/LoadingResultExtractor.php
@@ -73,8 +73,8 @@ final class LoadingResultExtractor Extends ResultExtractor
             if (array_key_exists($id, $valueObjectMapById)) {
                 $searchHit->valueObject = $valueObjectMapById[$id];
             } else {
-                //unset($searchResult->searchHits[$index]);
-                //--$searchResult->totalCount;
+                unset($searchResult->searchHits[$index]);
+                --$searchResult->totalCount;
             }
         }
 

--- a/lib/Core/Search/Solr/ResultExtractor/LoadingResultExtractor.php
+++ b/lib/Core/Search/Solr/ResultExtractor/LoadingResultExtractor.php
@@ -128,9 +128,9 @@ final class LoadingResultExtractor Extends ResultExtractor
 
     private function loadContentInfoMapByIdList(array $contentIdList)
     {
-        if (method_exists($this->contentHandler, 'loadContentInfoList')) {
-            return $this->contentHandler->loadContentInfoList($contentIdList);
-        }
+        //if (method_exists($this->contentHandler, 'loadContentInfoList')) {
+        //    return $this->contentHandler->loadContentInfoList($contentIdList);
+        //}
 
         $contentInfoList = [];
 
@@ -150,9 +150,9 @@ final class LoadingResultExtractor Extends ResultExtractor
      */
     private function loadLocationMapByIdList(array $locationIdList)
     {
-        if (method_exists($this->locationHandler, 'loadList')) {
-            return $this->locationHandler->loadList($locationIdList);
-        }
+        //if (method_exists($this->locationHandler, 'loadList')) {
+        //    return $this->locationHandler->loadList($locationIdList);
+        //}
 
         $locationList = [];
 

--- a/lib/Core/Search/Solr/ResultExtractor/LoadingResultExtractor.php
+++ b/lib/Core/Search/Solr/ResultExtractor/LoadingResultExtractor.php
@@ -78,8 +78,8 @@ final class LoadingResultExtractor Extends ResultExtractor
             if (array_key_exists($id, $valueObjectMapById)) {
                 $searchHit->valueObject = $valueObjectMapById[$id];
             } else {
-                unset($searchResult->searchHits[$index]);
-                --$searchResult->totalCount;
+                //unset($searchResult->searchHits[$index]);
+                //--$searchResult->totalCount;
             }
         }
 

--- a/lib/Core/Search/Solr/ResultExtractor/LoadingResultExtractor.php
+++ b/lib/Core/Search/Solr/ResultExtractor/LoadingResultExtractor.php
@@ -132,9 +132,9 @@ final class LoadingResultExtractor Extends ResultExtractor
 
     private function loadContentInfoMapByIdList(array $contentIdList)
     {
-        //if (method_exists($this->contentHandler, 'loadContentInfoList')) {
-        //    return $this->contentHandler->loadContentInfoList($contentIdList);
-        //}
+        if (method_exists($this->contentHandler, 'loadContentInfoList')) {
+            return $this->contentHandler->loadContentInfoList($contentIdList);
+        }
 
         $contentInfoList = [];
 
@@ -156,9 +156,9 @@ final class LoadingResultExtractor Extends ResultExtractor
      */
     private function loadLocationMapByIdList(array $locationIdList)
     {
-        //if (method_exists($this->locationHandler, 'loadList')) {
-        //    return $this->locationHandler->loadList($locationIdList);
-        //}
+        if (method_exists($this->locationHandler, 'loadList')) {
+            return $this->locationHandler->loadList($locationIdList);
+        }
 
         $locationList = [];
 

--- a/lib/Core/Search/Solr/ResultExtractor/LoadingResultExtractor.php
+++ b/lib/Core/Search/Solr/ResultExtractor/LoadingResultExtractor.php
@@ -78,7 +78,8 @@ final class LoadingResultExtractor Extends ResultExtractor
             if (array_key_exists($id, $valueObjectMapById)) {
                 $searchHit->valueObject = $valueObjectMapById[$id];
             } else {
-                // temp: do nothing
+                unset($searchResult->searchHits[$index]);
+                --$searchResult->totalCount;
             }
         }
 

--- a/lib/Core/Search/Solr/ResultExtractor/NativeResultExtractor.php
+++ b/lib/Core/Search/Solr/ResultExtractor/NativeResultExtractor.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\ResultExtractor;
+
+use EzSystems\EzPlatformSolrSearchEngine\Gateway\EndpointRegistry;
+use EzSystems\EzPlatformSolrSearchEngine\Query\FacetFieldVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor as BaseResultExtractor;
+use Netgen\EzPlatformSearchExtra\Core\Search\Solr\ResultExtractor;
+
+/**
+ * Native Result Extractor extracts the value object from the data returned by the Solr backend.
+ */
+final class NativeResultExtractor Extends ResultExtractor
+{
+    /**
+     * @var \EzSystems\EzPlatformSolrSearchEngine\ResultExtractor
+     */
+    private $nativeResultExtractor;
+
+    public function __construct(
+        BaseResultExtractor $nativeResultExtractor,
+        FacetFieldVisitor $facetBuilderVisitor,
+        EndpointRegistry $endpointRegistry
+    ) {
+        $this->nativeResultExtractor = $nativeResultExtractor;
+
+        parent::__construct($facetBuilderVisitor, $endpointRegistry);
+    }
+
+    protected function extractSearchResult($data, array $facetBuilders = [])
+    {
+        return $this->nativeResultExtractor->extract($data, $facetBuilders);
+    }
+
+    public function extractHit($hit)
+    {
+        return $this->nativeResultExtractor->extractHit($hit);
+    }
+}

--- a/lib/Resources/config/search/solr.yml
+++ b/lib/Resources/config/search/solr.yml
@@ -15,11 +15,22 @@ services:
             - '@netgen.search.solr.subdocument_mapper.content_translation.aggregate'
 
     netgen.search.solr.result_extractor:
-        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\ResultExtractor
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\ResultExtractor\NativeResultExtractor
         decorates: ezpublish.search.solr.result_extractor.native
         arguments:
             - '@netgen.search.solr.result_extractor.inner'
             - '@ezpublish.search.solr.query.content.facet_builder_visitor.aggregate'
+            - '@ezpublish.search.solr.gateway.endpoint_registry'
+
+    netgen.search.solr.result_extractor:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\ResultExtractor\LoadingResultExtractor
+        decorates: ezpublish.search.solr.result_extractor.native
+        arguments:
+            - '@ezpublish.spi.persistence.content_handler'
+            - '@ezpublish.spi.persistence.location_handler'
+            - '@netgen.search.solr.result_extractor.inner'
+            - '@ezpublish.search.solr.query.content.facet_builder_visitor.aggregate'
+            - '@ezpublish.search.solr.gateway.endpoint_registry'
 
     netgen.search.solr.query.content.query_converter:
         class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\QueryConverter

--- a/lib/Resources/config/search/solr.yml
+++ b/lib/Resources/config/search/solr.yml
@@ -15,14 +15,6 @@ services:
             - '@netgen.search.solr.subdocument_mapper.content_translation.aggregate'
 
     netgen.search.solr.result_extractor:
-        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\ResultExtractor\NativeResultExtractor
-        decorates: ezpublish.search.solr.result_extractor.native
-        arguments:
-            - '@netgen.search.solr.result_extractor.inner'
-            - '@ezpublish.search.solr.query.content.facet_builder_visitor.aggregate'
-            - '@ezpublish.search.solr.gateway.endpoint_registry'
-
-    netgen.search.solr.result_extractor:
         class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\ResultExtractor\LoadingResultExtractor
         decorates: ezpublish.search.solr.result_extractor.native
         arguments:

--- a/lib/Resources/config/search/solr.yml
+++ b/lib/Resources/config/search/solr.yml
@@ -39,3 +39,16 @@ services:
             - '@ezpublish.search.solr.query.location.criterion_visitor.aggregate'
             - '@ezpublish.search.solr.query.location.sort_clause_visitor.aggregate'
             - '@ezpublish.search.solr.query.location.facet_builder_visitor.aggregate'
+
+    netgen.spi.search.solr:
+        decorates: ezpublish.spi.search.solr
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Handler
+        arguments:
+            - "@ezpublish.search.solr.gateway"
+            - "@ezpublish.spi.persistence.content_handler"
+            - "@ezpublish.search.solr.document_mapper"
+            - "@ezpublish.search.solr.result_extractor"
+            - "@ezpublish.search.solr.core_filter"
+        tags:
+            - {name: ezpublish.searchEngine, alias: solr}
+        lazy: true

--- a/tests/bundle/DependencyInjection/NetgenEzPlatformSearchExtraExtensionTest.php
+++ b/tests/bundle/DependencyInjection/NetgenEzPlatformSearchExtraExtensionTest.php
@@ -102,6 +102,21 @@ class NetgenEzPlatformSearchExtraExtensionTest extends AbstractExtensionTestCase
                     ],
                 ],
             ],
+            [
+                [
+                    'use_native_search_result_extractor' => false,
+                    'indexable_field_type' => [
+                        'ezxmltext' => [
+                            'enabled' => true,
+                            'short_text_limit' => 256
+                        ],
+                        'ezrichtext' => [
+                            'enabled' => true,
+                            'short_text_limit' => 256
+                        ],
+                    ],
+                ],
+            ],
         ];
     }
 
@@ -114,7 +129,10 @@ class NetgenEzPlatformSearchExtraExtensionTest extends AbstractExtensionTestCase
     {
         $this->load($configuration);
 
-
+        $this->assertContainerBuilderHasParameter(
+            'netgen_ez_platform_search_extra.use_native_search_result_extractor',
+            false
+        );
         $this->assertContainerBuilderHasParameter(
             'netgen_ez_platform_search_extra.indexable_field_type.ezrichtext.enabled',
             true

--- a/tests/bundle/DependencyInjection/NetgenEzPlatformSearchExtraExtensionTest.php
+++ b/tests/bundle/DependencyInjection/NetgenEzPlatformSearchExtraExtensionTest.php
@@ -104,7 +104,7 @@ class NetgenEzPlatformSearchExtraExtensionTest extends AbstractExtensionTestCase
             ],
             [
                 [
-                    'use_native_search_result_extractor' => false,
+                    'use_loading_search_result_extractor' => true,
                     'indexable_field_type' => [
                         'ezxmltext' => [
                             'enabled' => true,
@@ -130,8 +130,8 @@ class NetgenEzPlatformSearchExtraExtensionTest extends AbstractExtensionTestCase
         $this->load($configuration);
 
         $this->assertContainerBuilderHasParameter(
-            'netgen_ez_platform_search_extra.use_native_search_result_extractor',
-            false
+            'netgen_ez_platform_search_extra.use_loading_search_result_extractor',
+            true
         );
         $this->assertContainerBuilderHasParameter(
             'netgen_ez_platform_search_extra.indexable_field_type.ezrichtext.enabled',


### PR DESCRIPTION
With this loading result extractor is enabled by default, it can be disabled with semantic configuration:

```yaml
netgen_ez_platform_search_extra:
    use_native_search_result_extractor: true
```

This this we avoid the situation where unauthorized exception is thrown because the user does not have access to content/versionread. This happens if search is executed while Solr index is not yet up-to-date, so incorrect current version is returned (the previous one).

Testing: integration tests and manual testing.