### PR TITLE
Add field facet builder support for solr

### DIFF
--- a/lib/Core/Search/Solr/Query/Common/FacetBuilderVisitor/FieldFacetBuilderVisitor.php
+++ b/lib/Core/Search/Solr/Query/Common/FacetBuilderVisitor/FieldFacetBuilderVisitor.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\FacetBuilderVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
+use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder\FieldFacetBuilder;
+use eZ\Publish\API\Repository\Values\Content\Search\Facet\FieldFacet;
+use eZ\Publish\Core\Search\Common\FieldNameResolver;
+use EzSystems\EzPlatformSolrSearchEngine\Query\FacetBuilderVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\Query\FacetFieldVisitor;
+
+/**
+ * Visits the Field facet builder.
+ */
+class FieldFacetBuilderVisitor extends FacetBuilderVisitor implements FacetFieldVisitor
+{
+    /**
+     * @var FieldNameResolver
+     */
+    private $fieldNameResolver;
+
+    public function __construct(FieldNameResolver $fieldNameResolver)
+    {
+        $this->fieldNameResolver = $fieldNameResolver;
+    }
+
+    public function mapField($field, array $data, FacetBuilder $facetBuilder)
+    {
+        $values = [];
+        $totalCount = 0;
+        $missingCount = 0;
+
+        reset($data);
+        while ($key = current($data)) {
+            $totalCount += $values[$key] = next($data);
+            next($data);
+        }
+
+        if (current($data) === null) {
+            $totalCount += $missingCount = next($data);
+        }
+
+        return new FieldFacet([
+            'name' => $facetBuilder->name,
+            'entries' => $values,
+            'missingCount' => $missingCount,
+            'totalCount' => $totalCount,
+            'otherCount' => $totalCount - $missingCount,
+        ]);
+    }
+
+    public function canVisit(FacetBuilder $facetBuilder)
+    {
+        return $facetBuilder instanceof FieldFacetBuilder;
+    }
+
+    public function visitBuilder(FacetBuilder $facetBuilder, $fieldId)
+    {
+        $parameters = [];
+        $criteria = new Criterion\MatchAll();
+        $fieldPaths = $facetBuilder->fieldPaths;
+
+        $parts = explode(':', $fieldPaths);
+        if (count($parts) > 1) {
+            $contentTypeIdentifier = $parts[0];
+            $criteria = new Criterion\ContentTypeIdentifier($contentTypeIdentifier);
+            $fieldPaths = $parts[1];
+        }
+
+        $parts = explode('/', $fieldPaths);
+        $fieldDefinitionIdentifier = $parts[0];
+        $name = isset($parts[1]) ? $parts[1] : null;
+
+        $fieldTypes = $this->fieldNameResolver->getFieldTypes(
+            $criteria,
+            $fieldDefinitionIdentifier,
+            null,
+            $name
+        );
+
+        foreach ($fieldTypes as $fieldName => $fieldType) {
+            $parameters = array_merge($parameters, [
+                'facet.field' => "{!ex=dt key={$fieldId}}{$fieldName}",
+                "f.{$fieldName}.facet.limit" => $facetBuilder->limit,
+                "f.{$fieldName}.facet.mincount" => $facetBuilder->minCount,
+                "f.{$fieldName}.facet.sort" => $this->getSort($facetBuilder),
+                "f.{$fieldName}.facet.missing" => 'true',
+            ]);
+        }
+
+        return $parameters;
+    }
+
+    private function getSort(FieldFacetBuilder $facetBuilder)
+    {
+        switch ($facetBuilder->sort) {
+            case FieldFacetBuilder::COUNT_DESC:
+                return 'count';
+            case FieldFacetBuilder::TERM_ASC:
+                return 'index';
+        }
+
+        return 'index';
+    }
+}

--- a/lib/Resources/config/search/solr/facet_builder_visitors.yml
+++ b/lib/Resources/config/search/solr/facet_builder_visitors.yml
@@ -5,6 +5,13 @@ services:
             - {name: ezpublish.search.solr.query.content.facet_builder_visitor}
             - {name: ezpublish.search.solr.query.location.facet_builder_visitor}
 
+    netgen.search.solr.query.common.facet_builder_visitor.field:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\FacetBuilderVisitor\FieldFacetBuilderVisitor
+        arguments: ["@ezpublish.search.common.field_name_resolver"]
+        tags:
+            - {name: ezpublish.search.solr.query.content.facet_builder_visitor}
+            - {name: ezpublish.search.solr.query.location.facet_builder_visitor}
+
     netgen.search.solr.query.common.facet_builder_visitor.raw:
         class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\FacetBuilderVisitor\RawFacetBuilderVisitor
         tags:


### PR DESCRIPTION
Not sure if this fits here but thought I would add it.  Add support for field facets using solr until  https://jira.ez.no/browse/EZP-27458 is addressed.

Examples
----------
```
           new FacetBuilder\FieldFacetBuilder([
                'name' => 'Specialties',
                'fieldPaths' => 'agent:specialties/tag_ids',
                'limit' => 9999,
            ]),
            new FacetBuilder\FieldFacetBuilder([
                'name' => 'Province',
                'fieldPaths' => 'agent:province',
                'limit' => 9999,
            ]),
```