### PR TITLE
Implement domain support on the RawFacetBuilder

### DIFF
--- a/bundle/NetgenEzPlatformSearchExtraBundle.php
+++ b/bundle/NetgenEzPlatformSearchExtraBundle.php
@@ -21,5 +21,6 @@ class NetgenEzPlatformSearchExtraBundle extends Bundle
         $containerBuilder->addCompilerPass(new Compiler\FieldType\RichTextIndexablePass());
         $containerBuilder->addCompilerPass(new Compiler\FieldType\XmlTextIndexablePass());
         $containerBuilder->addCompilerPass(new Compiler\SearchResultExtractorPass());
+        $containerBuilder->addCompilerPass(new Compiler\RawFacetBuilderDomainVisitorPass());
     }
 }

--- a/lib/Container/Compiler/RawFacetBuilderDomainVisitorPass.php
+++ b/lib/Container/Compiler/RawFacetBuilderDomainVisitorPass.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Container\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * This compiler pass will register RawFacetBuilder Domain visitors.
+ *
+ * @see \Netgen\EzPlatformSearchExtra\Core\Search\Solr\API\FacetBuilder\RawFacetBuilder\Domain
+ * @see \Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\FacetBuilderVisitor\RawFacetBuilderVisitor\DomainVisitor\Aggregate
+ */
+final class RawFacetBuilderDomainVisitorPass implements CompilerPassInterface
+{
+    private static $aggregateVisitorId = 'netgen.search.solr.query.common.facet_builder_visitor.raw.domain_visitor.aggregate';
+    private static $visitorTag = 'netgen.search.solr.query.common.facet_builder_visitor.raw.domain_visitor';
+
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition(static::$aggregateVisitorId)) {
+            return;
+        }
+
+        $aggregateDefinition = $container->getDefinition(static::$aggregateVisitorId);
+        $mapperIds = $container->findTaggedServiceIds(static::$visitorTag);
+
+        $this->registerMappers($aggregateDefinition, $mapperIds);
+    }
+
+    private function registerMappers(Definition $definition, array $visitorIds)
+    {
+        foreach (array_keys($visitorIds) as $id) {
+            $definition->addMethodCall('addVisitor', [new Reference($id)]);
+        }
+    }
+}

--- a/lib/Core/Search/Solr/API/FacetBuilder/RawFacetBuilder.php
+++ b/lib/Core/Search/Solr/API/FacetBuilder/RawFacetBuilder.php
@@ -15,14 +15,19 @@ class RawFacetBuilder extends FacetBuilder
      * Example:
      *
      * ```php
-     * $facet->parameters = [
-     *     'type': 'terms'
-     *     'field' => 'genre',
-     *     'limit' => 5,
-     * ];
+     *  $facet->parameters = [
+     *      'type': 'terms'
+     *      'field' => 'genre',
+     *      'limit' => 5,
+     *  ];
      * ```
      *
      * @var array
      */
     public $parameters;
+
+    /**
+     * @var \Netgen\EzPlatformSearchExtra\Core\Search\Solr\API\FacetBuilder\RawFacetBuilder\Domain|null
+     */
+    public $domain;
 }

--- a/lib/Core/Search/Solr/API/FacetBuilder/RawFacetBuilder/Domain.php
+++ b/lib/Core/Search/Solr/API/FacetBuilder/RawFacetBuilder/Domain.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\API\FacetBuilder\RawFacetBuilder;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * Represents a domain for RawFacetBuilder.
+ *
+ * @see \Netgen\EzPlatformSearchExtra\Core\Search\Solr\API\FacetBuilder\RawFacetBuilder
+ */
+abstract class Domain extends ValueObject
+{
+}

--- a/lib/Core/Search/Solr/API/FacetBuilder/RawFacetBuilder/Domain/BlockChildren.php
+++ b/lib/Core/Search/Solr/API/FacetBuilder/RawFacetBuilder/Domain/BlockChildren.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\API\FacetBuilder\RawFacetBuilder\Domain;
+
+use Netgen\EzPlatformSearchExtra\Core\Search\Solr\API\FacetBuilder\RawFacetBuilder\Domain;
+
+/**
+ * BlockChildren block-join domain for RawFacetBuilder.
+ *
+ * @see \Netgen\EzPlatformSearchExtra\Core\Search\Solr\API\FacetBuilder\RawFacetBuilder
+ */
+class BlockChildren extends Domain
+{
+    /**
+     * @var string
+     */
+    public $parentDocumentIdentifier;
+
+    /**
+     * @var string
+     */
+    public $childDocumentIdentifier;
+
+    /**
+     * @var \eZ\Publish\API\Repository\Values\Content\Query\Criterion|null
+     */
+    public $filter;
+}

--- a/lib/Core/Search/Solr/Query/Common/FacetBuilderVisitor/RawFacetBuilderVisitor.php
+++ b/lib/Core/Search/Solr/Query/Common/FacetBuilderVisitor/RawFacetBuilderVisitor.php
@@ -7,37 +7,48 @@ use EzSystems\EzPlatformSolrSearchEngine\Query\FacetFieldVisitor;
 use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
 use Netgen\EzPlatformSearchExtra\Core\Search\Solr\API\Facet\RawFacet;
 use Netgen\EzPlatformSearchExtra\Core\Search\Solr\API\FacetBuilder\RawFacetBuilder;
+use Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\FacetBuilderVisitor\RawFacetBuilderVisitor\DomainVisitor;
 
 /**
- * Visits the ContentType facet builder.
+ * Visits the RawFacetBuilder.
  */
 class RawFacetBuilderVisitor extends FacetBuilderVisitor implements FacetFieldVisitor
 {
     /**
-     * {@inheritdoc}.
+     * @var \Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\FacetBuilderVisitor\RawFacetBuilderVisitor\DomainVisitor
      */
+    private $domainVisitor;
+
+    /**
+     * @param \Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\FacetBuilderVisitor\RawFacetBuilderVisitor\DomainVisitor $domainVisitor
+     */
+    public function __construct(DomainVisitor $domainVisitor)
+    {
+        $this->domainVisitor = $domainVisitor;
+    }
+
     public function mapField($field, array $data, FacetBuilder $facetBuilder)
     {
         return new RawFacet([
             'name' => $facetBuilder->name,
-            'data' => reset($data),
+            'data' => \reset($data),
         ]);
     }
 
-    /**
-     * {@inheritdoc}.
-     */
     public function canVisit(FacetBuilder $facetBuilder)
     {
         return $facetBuilder instanceof RawFacetBuilder;
     }
 
-    /**
-     * {@inheritdoc}.
-     */
     public function visitBuilder(FacetBuilder $facetBuilder, $fieldId)
     {
         /** @var $facetBuilder \Netgen\EzPlatformSearchExtra\Core\Search\Solr\API\FacetBuilder\RawFacetBuilder */
-        return $facetBuilder->parameters;
+        $parameters = $facetBuilder->parameters;
+
+        if ($facetBuilder->domain !== null) {
+            $parameters['domain'] = $this->domainVisitor->visit($facetBuilder->domain);
+        }
+
+        return $parameters;
     }
 }

--- a/lib/Core/Search/Solr/Query/Common/FacetBuilderVisitor/RawFacetBuilderVisitor/DomainVisitor.php
+++ b/lib/Core/Search/Solr/Query/Common/FacetBuilderVisitor/RawFacetBuilderVisitor/DomainVisitor.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\FacetBuilderVisitor\RawFacetBuilderVisitor;
+
+use Netgen\EzPlatformSearchExtra\Core\Search\Solr\API\FacetBuilder\RawFacetBuilder\Domain;
+
+abstract class DomainVisitor
+{
+    /**
+     * @param \Netgen\EzPlatformSearchExtra\Core\Search\Solr\API\FacetBuilder\RawFacetBuilder\Domain $domain
+     *
+     * @return bool
+     */
+    abstract public function accept(Domain $domain);
+
+    /**
+     * @param \Netgen\EzPlatformSearchExtra\Core\Search\Solr\API\FacetBuilder\RawFacetBuilder\Domain $domain
+     *
+     * @return array
+     */
+    abstract public function visit(Domain $domain);
+}

--- a/lib/Core/Search/Solr/Query/Common/FacetBuilderVisitor/RawFacetBuilderVisitor/DomainVisitor/Aggregate.php
+++ b/lib/Core/Search/Solr/Query/Common/FacetBuilderVisitor/RawFacetBuilderVisitor/DomainVisitor/Aggregate.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\FacetBuilderVisitor\RawFacetBuilderVisitor\DomainVisitor;
+
+use OutOfBoundsException;
+use Netgen\EzPlatformSearchExtra\Core\Search\Solr\API\FacetBuilder\RawFacetBuilder\Domain;
+use Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\FacetBuilderVisitor\RawFacetBuilderVisitor\DomainVisitor;
+
+class Aggregate extends DomainVisitor
+{
+    /**
+     * @var \Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\FacetBuilderVisitor\RawFacetBuilderVisitor\DomainVisitor[]
+     */
+    private $visitors = [];
+
+    /**
+     * @param \Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\FacetBuilderVisitor\RawFacetBuilderVisitor\DomainVisitor[] $visitors
+     */
+    public function __construct(array $visitors = [])
+    {
+        foreach ($visitors as $visitor) {
+            $this->addVisitor($visitor);
+        }
+    }
+
+    public function addVisitor(DomainVisitor $visitor)
+    {
+        $this->visitors[] = $visitor;
+    }
+
+    public function accept(Domain $domain)
+    {
+        return true;
+    }
+
+    public function visit(Domain $domain)
+    {
+        foreach ($this->visitors as $visitor) {
+            if ($visitor->accept($domain)) {
+                return $visitor->visit($domain);
+            }
+        }
+
+        throw new OutOfBoundsException('No visitor found for the given domain');
+    }
+}

--- a/lib/Core/Search/Solr/Query/Common/FacetBuilderVisitor/RawFacetBuilderVisitor/DomainVisitor/BlockChildren.php
+++ b/lib/Core/Search/Solr/Query/Common/FacetBuilderVisitor/RawFacetBuilderVisitor/DomainVisitor/BlockChildren.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\FacetBuilderVisitor\RawFacetBuilderVisitor\DomainVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\CustomField;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\SubdocumentQuery;
+use Netgen\EzPlatformSearchExtra\Core\Search\Solr\API\FacetBuilder\RawFacetBuilder\Domain;
+use Netgen\EzPlatformSearchExtra\Core\Search\Solr\API\FacetBuilder\RawFacetBuilder\Domain\BlockChildren as BlockChildrenDomain;
+use Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\FacetBuilderVisitor\RawFacetBuilderVisitor\DomainVisitor;
+
+class BlockChildren extends DomainVisitor
+{
+    /**
+     * @var \EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor
+     */
+    private $subdocumentQueryCriterionVisitor;
+
+    /**
+     * @param \EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor $subdocumentQueryCriterionVisitor
+     */
+    public function __construct(CriterionVisitor $subdocumentQueryCriterionVisitor)
+    {
+        $this->subdocumentQueryCriterionVisitor = $subdocumentQueryCriterionVisitor;
+    }
+
+    public function accept(Domain $domain)
+    {
+        return $domain instanceof BlockChildrenDomain;
+    }
+
+    public function visit(Domain $domain)
+    {
+        \assert($domain instanceof BlockChildrenDomain);
+
+        return [
+            'blockChildren' => "document_type_id:{$domain->parentDocumentIdentifier}",
+            'filter' => $this->subdocumentQueryCriterionVisitor->visit(
+                $this->getFilterCriteria($domain)
+            ),
+        ];
+    }
+
+    private function getFilterCriteria(BlockChildrenDomain $domain)
+    {
+        $criteria = new CustomField('document_type_id', Operator::EQ, $domain->childDocumentIdentifier);
+
+        if ($domain->filter !== null) {
+            $criteria = new LogicalAnd([$criteria, $domain->filter]);
+        }
+
+        return $criteria;
+    }
+}

--- a/lib/Resources/config/search/solr/facet_builder_visitors.yml
+++ b/lib/Resources/config/search/solr/facet_builder_visitors.yml
@@ -1,3 +1,6 @@
+imports:
+    - { resource: facet_builder_visitors/raw_facet_domain_visitors.yml }
+
 services:
     netgen.search.solr.query.common.facet_builder_visitor.custom_field:
         class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\FacetBuilderVisitor\CustomFieldFacetBuilderVisitor
@@ -7,6 +10,8 @@ services:
 
     netgen.search.solr.query.common.facet_builder_visitor.raw:
         class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\FacetBuilderVisitor\RawFacetBuilderVisitor
+        arguments:
+            - '@netgen.search.solr.query.common.facet_builder_visitor.raw.domain_visitor.aggregate'
         tags:
             - {name: ezpublish.search.solr.query.content.facet_builder_visitor}
             - {name: ezpublish.search.solr.query.location.facet_builder_visitor}

--- a/lib/Resources/config/search/solr/facet_builder_visitors/raw_facet_domain_visitors.yml
+++ b/lib/Resources/config/search/solr/facet_builder_visitors/raw_facet_domain_visitors.yml
@@ -1,0 +1,12 @@
+services:
+    # Note: services tagged with 'netgen.search.solr.query.common.facet_builder_visitor.raw.domain_visitor'
+    # are registered to this one using container compiler pass
+    netgen.search.solr.query.common.facet_builder_visitor.raw.domain_visitor.aggregate:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\FacetBuilderVisitor\RawFacetBuilderVisitor\DomainVisitor\Aggregate
+
+    netgen.search.solr.query.common.facet_builder_visitor.raw.domain_visitor.block_children:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\FacetBuilderVisitor\RawFacetBuilderVisitor\DomainVisitor\BlockChildren
+        arguments:
+            - '@netgen.search.solr.query.content.criterion_visitor.subdocument_query.aggregate'
+        tags:
+            - { name: netgen.search.solr.query.common.facet_builder_visitor.raw.domain_visitor }

--- a/phpunit-integration-legacy.xml
+++ b/phpunit-integration-legacy.xml
@@ -16,6 +16,7 @@
             <exclude>tests/lib/API/IsFieldEmptyCriterionTest.php</exclude>
             <exclude>tests/lib/API/SubdocumentFieldSortClauseTest.php</exclude>
             <exclude>tests/lib/API/SubdocumentQueryCriterionTest.php</exclude>
+            <exclude>tests/lib/Solr/RawFacetDomainTest.php</exclude>
             <exclude>tests/lib/Solr/RawFacetTest.php</exclude>
         </testsuite>
     </testsuites>

--- a/tests/lib/SetupFactory/Solr.php
+++ b/tests/lib/SetupFactory/Solr.php
@@ -34,5 +34,6 @@ class Solr extends CoreSolrSetupFactory
         $containerBuilder->addCompilerPass(new Compiler\AggregateContentSubdocumentMapperPass());
         $containerBuilder->addCompilerPass(new Compiler\AggregateContentTranslationSubdocumentMapperPass());
         $containerBuilder->addCompilerPass(new Compiler\AggregateSubdocumentQueryCriterionVisitorPass());
+        $containerBuilder->addCompilerPass(new Compiler\RawFacetBuilderDomainVisitorPass());
     }
 }

--- a/tests/lib/Solr/RawFacetDomainTest.php
+++ b/tests/lib/Solr/RawFacetDomainTest.php
@@ -3,7 +3,6 @@
 namespace Netgen\EzPlatformSearchExtra\Tests\Solr;
 
 use eZ\Publish\API\Repository\Tests\BaseTest;
-use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentId;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\CustomField;
@@ -18,7 +17,7 @@ class RawFacetDomainTest extends BaseTest
     {
         return [
             [
-                new LocationQuery([
+                new Query([
                     'facetBuilders' => [
                         new RawFacetBuilder([
                             'name' => 'test_facet',
@@ -80,7 +79,7 @@ class RawFacetDomainTest extends BaseTest
                 ],
             ],
             [
-                new LocationQuery([
+                new Query([
                     'facetBuilders' => [
                         new RawFacetBuilder([
                             'name' => 'test_facet',
@@ -136,7 +135,7 @@ class RawFacetDomainTest extends BaseTest
                 ],
             ],
             [
-                new LocationQuery([
+                new Query([
                     'facetBuilders' => [
                         new RawFacetBuilder([
                             'name' => 'test_facet',

--- a/tests/lib/Solr/RawFacetDomainTest.php
+++ b/tests/lib/Solr/RawFacetDomainTest.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Tests\Solr;
+
+use eZ\Publish\API\Repository\Tests\BaseTest;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentId;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\CustomField;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use Netgen\EzPlatformSearchExtra\Core\Search\Solr\API\Facet\RawFacet;
+use Netgen\EzPlatformSearchExtra\Core\Search\Solr\API\FacetBuilder\RawFacetBuilder;
+use Netgen\EzPlatformSearchExtra\Core\Search\Solr\API\FacetBuilder\RawFacetBuilder\Domain\BlockChildren;
+
+class RawFacetDomainTest extends BaseTest
+{
+    public function providerForTestFind()
+    {
+        return [
+            [
+                new LocationQuery([
+                    'facetBuilders' => [
+                        new RawFacetBuilder([
+                            'name' => 'test_facet',
+                            'parameters' => [
+                                'type' => 'terms',
+                                'field' => 'price_i',
+                                'allBuckets' => true,
+                                'sort' => 'count desc',
+                                'facet' => [
+                                    'maximum' => 'max(price_i)',
+                                    'minimum' => 'min(price_i)',
+                                ],
+                            ],
+                            'domain' => new BlockChildren([
+                                'parentDocumentIdentifier' => 'content',
+                                'childDocumentIdentifier' => 'test_content_subdocument',
+                                'filter' => null,
+                            ]),
+                        ]),
+                    ],
+                    'filter' => new ContentId([4, 12, 13, 42, 59]),
+                    'limit' => 0,
+                ]),
+                [
+                    new RawFacet([
+                        'name' => 'test_facet',
+                        'data' => json_decode(
+                            json_encode(
+                                [
+                                    'allBuckets' => [
+                                        'count' => 4,
+                                        'maximum' => 60.0,
+                                        'minimum' => 40.0,
+                                    ],
+                                    'buckets' => [
+                                        [
+                                            'val' => 50,
+                                            'count' => 2,
+                                            'maximum' => 50.0,
+                                            'minimum' => 50.0,
+                                        ],
+                                        [
+                                            'val' => 40,
+                                            'count' => 1,
+                                            'maximum' => 40.0,
+                                            'minimum' => 40.0,
+                                        ],
+                                        [
+                                            'val' => 60,
+                                            'count' => 1,
+                                            'maximum' => 60.0,
+                                            'minimum' => 60.0,
+                                        ],
+                                    ],
+                                ]
+                            )
+                        ),
+                    ]),
+                ],
+            ],
+            [
+                new LocationQuery([
+                    'facetBuilders' => [
+                        new RawFacetBuilder([
+                            'name' => 'test_facet',
+                            'parameters' => [
+                                'type' => 'terms',
+                                'field' => 'price_i',
+                                'allBuckets' => true,
+                                'sort' => 'count desc',
+                                'facet' => [
+                                    'maximum' => 'max(price_i)',
+                                    'minimum' => 'min(price_i)',
+                                ],
+                            ],
+                            'domain' => new BlockChildren([
+                                'parentDocumentIdentifier' => 'content',
+                                'childDocumentIdentifier' => 'test_content_subdocument',
+                                'filter' => new CustomField('visible_b', Operator::EQ, true),
+                            ]),
+                        ]),
+                    ],
+                    'filter' => new ContentId([4, 12, 13, 42, 59]),
+                    'limit' => 0,
+                ]),
+                [
+                    new RawFacet([
+                        'name' => 'test_facet',
+                        'data' => json_decode(
+                            json_encode(
+                                [
+                                    'allBuckets' => [
+                                        'count' => 2,
+                                        'maximum' => 60.0,
+                                        'minimum' => 40.0,
+                                    ],
+                                    'buckets' => [
+                                        [
+                                            'val' => 40,
+                                            'count' => 1,
+                                            'maximum' => 40.0,
+                                            'minimum' => 40.0,
+                                        ],
+                                        [
+                                            'val' => 60,
+                                            'count' => 1,
+                                            'maximum' => 60.0,
+                                            'minimum' => 60.0,
+                                        ],
+                                    ],
+                                ]
+                            )
+                        ),
+                    ]),
+                ],
+            ],
+            [
+                new LocationQuery([
+                    'facetBuilders' => [
+                        new RawFacetBuilder([
+                            'name' => 'test_facet',
+                            'parameters' => [
+                                'type' => 'terms',
+                                'field' => 'price_i',
+                                'allBuckets' => true,
+                                'sort' => 'count desc',
+                                'facet' => [
+                                    'maximum' => 'max(price_i)',
+                                    'minimum' => 'min(price_i)',
+                                ],
+                            ],
+                            'domain' => new BlockChildren([
+                                'parentDocumentIdentifier' => 'content',
+                                'childDocumentIdentifier' => 'test_content_subdocument',
+                                'filter' => new CustomField('visible_b', Operator::EQ, false),
+                            ]),
+                        ]),
+                    ],
+                    'filter' => new ContentId([4, 12, 13, 42, 59]),
+                    'limit' => 0,
+                ]),
+                [
+                    new RawFacet([
+                        'name' => 'test_facet',
+                        'data' => json_decode(
+                            json_encode(
+                                [
+                                    'allBuckets' => [
+                                        'count' => 2,
+                                        'maximum' => 50.0,
+                                        'minimum' => 50.0,
+                                    ],
+                                    'buckets' => [
+                                        [
+                                            'val' => 50,
+                                            'count' => 2,
+                                            'maximum' => 50.0,
+                                            'minimum' => 50.0,
+                                        ],
+                                    ],
+                                ]
+                            )
+                        ),
+                    ]),
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForTestFind
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     * @param \eZ\Publish\API\Repository\Values\Content\Search\Facet[] $expectedFacets
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testFindContent(Query $query, array $expectedFacets)
+    {
+        $searchService = $this->getSearchService(false);
+
+        $searchResult = $searchService->findContentInfo($query);
+
+        $this->assertEquals($expectedFacets, $searchResult->facets);
+    }
+
+    protected function getSearchService($initialInitializeFromScratch = true)
+    {
+        return $this->getRepository($initialInitializeFromScratch)->getSearchService();
+    }
+}


### PR DESCRIPTION
This implements support for domains (https://lucene.apache.org/solr/guide/7_5/json-facet-api.html#changing-the-domain) on the RawFacetBuilder, for now with `BlockChildren` domain support:

```php
$query = new Query([
    'facetBuilders' => [
        new RawFacetBuilder([
            'name' => 'test_facet',
            'parameters' => [
                'type' => 'terms',
                'field' => 'price_i',
                'allBuckets' => true,
                'sort' => 'count desc',
                'facet' => [
                    'maximum' => 'max(price_i)',
                    'minimum' => 'min(price_i)',
                ],
            ],
            'domain' => new BlockChildren([
                'parentDocumentIdentifier' => 'content',
                'childDocumentIdentifier' => 'test_content_subdocument',
                'filter' => new CustomField('visible_b', Operator::EQ, true),
            ]),
        ]),
    ],
    'filter' => new ContentId([4, 12, 13, 42, 59]),
    'limit' => 0,
]);
```
