### PR TITLE
NGSTACK-351: make compiler passes compatible with SF 2.8

### DIFF
--- a/lib/Container/Compiler/FieldType/RichTextIndexablePass.php
+++ b/lib/Container/Compiler/FieldType/RichTextIndexablePass.php
@@ -31,7 +31,7 @@ class RichTextIndexablePass implements CompilerPassInterface
         $definition = $container->findDefinition($originalServiceId);
 
         $definition->setClass(IndexableRichText::class);
-        $definition->setArgument(0, $shortTextLimit);
+        $definition->addArgument($shortTextLimit);
         $definition->addTag('ezpublish.fieldType.indexable', ['alias' => 'ezrichtext']);
 
         $container->setDefinition($originalServiceId, $definition);

--- a/lib/Container/Compiler/FieldType/XmlTextIndexablePass.php
+++ b/lib/Container/Compiler/FieldType/XmlTextIndexablePass.php
@@ -29,7 +29,7 @@ class XmlTextIndexablePass implements CompilerPassInterface
         $definition = $container->findDefinition($originalServiceId);
 
         $definition->setClass(IndexableXmlText::class);
-        $definition->setArgument(0, $shortTextLimit);
+        $definition->addArgument($shortTextLimit);
         $definition->addTag('ezpublish.fieldType.indexable', ['alias' => 'ezxmltext']);
 
         $container->setDefinition($originalServiceId, $definition);

--- a/lib/Container/Compiler/FieldTypeRegistryPass.php
+++ b/lib/Container/Compiler/FieldTypeRegistryPass.php
@@ -25,6 +25,8 @@ class FieldTypeRegistryPass implements CompilerPassInterface
         $fieldTypeRegistry = $container->findDefinition('ezpublish.persistence.field_type_registry');
         $fieldTypeRegistry->setClass($fieldTypeRegistryClass);
 
-        $fieldTypeRegistry->replaceArgument(0, $fieldTypeRegistryClass);
+        if (count($fieldTypeRegistry->getArguments()) > 0) {
+            $fieldTypeRegistry->replaceArgument(0, $fieldTypeRegistryClass);
+        }
     }
 }

--- a/lib/Container/Compiler/FieldTypeRegistryPass.php
+++ b/lib/Container/Compiler/FieldTypeRegistryPass.php
@@ -25,8 +25,6 @@ class FieldTypeRegistryPass implements CompilerPassInterface
         $fieldTypeRegistry = $container->findDefinition('ezpublish.persistence.field_type_registry');
         $fieldTypeRegistry->setClass($fieldTypeRegistryClass);
 
-        if (count($fieldTypeRegistry->getArguments()) > 0) {
-            $fieldTypeRegistry->setArgument(0, $fieldTypeRegistryClass);
-        }
+        $fieldTypeRegistry->replaceArgument(0, $fieldTypeRegistryClass);
     }
 }


### PR DESCRIPTION
Fixes #27 

I didn't use if/else logic as suggested in the issue. Since original `IndexableRichText` and `IndexableXmlText` do not have any arguments it should be safe to use `addArgument`.

For `FieldTypeRegistry` it should be enough to use `replaceArgument` without check, because if anything changes in the original class we will need to adapt our implementation anyway.