### PR TITLE
NGSTACK-436: implement Visible criterion

### DIFF
--- a/lib/API/Values/Content/Query/Criterion/Visible.php
+++ b/lib/API/Values/Content/Query/Criterion/Visible.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
+
+class Visible extends Criterion
+{
+    public function __construct(bool $value)
+    {
+        parent::__construct(null, null, $value);
+    }
+
+    public function getSpecifications(): array
+    {
+        return [
+            new Specifications(
+                Operator::EQ,
+                Specifications::FORMAT_SINGLE,
+                Specifications::TYPE_BOOLEAN
+            ),
+        ];
+    }
+}

--- a/lib/Core/Search/Legacy/Query/Content/CriterionHandler/Visible.php
+++ b/lib/Core/Search/Legacy/Query/Content/CriterionHandler/Visible.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Legacy\Query\Content\CriterionHandler;
+
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Query\QueryBuilder;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\Visible as VisibleCriterion;
+
+class Visible extends CriterionHandler
+{
+    public function accept(Criterion $criterion)
+    {
+        return $criterion instanceof VisibleCriterion;
+    }
+
+    public function handle(
+        CriteriaConverter $converter,
+        QueryBuilder $queryBuilder,
+        Criterion $criterion,
+        array $languageSettings
+    ) {
+        $isHiddenInteger = (int)!$criterion->value[0];
+
+        return $queryBuilder->expr()->eq(
+            'c.is_hidden',
+            $queryBuilder->createNamedParameter($isHiddenInteger, ParameterType::INTEGER)
+        );
+    }
+}

--- a/lib/Core/Search/Legacy/Query/Location/CriterionHandler/Visible.php
+++ b/lib/Core/Search/Legacy/Query/Location/CriterionHandler/Visible.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Legacy\Query\Location\CriterionHandler;
+
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Query\QueryBuilder;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\Visible as VisibleCriterion;
+
+class Visible extends CriterionHandler
+{
+    public function accept(Criterion $criterion)
+    {
+        return $criterion instanceof VisibleCriterion;
+    }
+
+    public function handle(
+        CriteriaConverter $converter,
+        QueryBuilder $queryBuilder,
+        Criterion $criterion,
+        array $languageSettings
+    ) {
+        $isVisible = $criterion->value[0];
+        $expr = $queryBuilder->expr();
+
+        if ($isVisible) {
+            return $expr->andX(
+                $expr->eq(
+                    't.is_hidden',
+                    $queryBuilder->createNamedParameter(0, ParameterType::INTEGER)
+                ),
+                $expr->eq(
+                    't.is_invisible',
+                    $queryBuilder->createNamedParameter(0, ParameterType::INTEGER)
+                ),
+                $expr->eq(
+                    'c.is_hidden',
+                    $queryBuilder->createNamedParameter(0, ParameterType::INTEGER)
+                ),
+            );
+        }
+
+        return $expr->orX(
+            $expr->eq(
+                't.is_hidden',
+                $queryBuilder->createNamedParameter(1, ParameterType::INTEGER)
+            ),
+            $expr->eq(
+                't.is_invisible',
+                $queryBuilder->createNamedParameter(1, ParameterType::INTEGER)
+            ),
+            $expr->eq(
+                'c.is_hidden',
+                $queryBuilder->createNamedParameter(1, ParameterType::INTEGER)
+            ),
+        );
+    }
+}

--- a/lib/Core/Search/Solr/FieldMapper/Content/ContentVisibilityFieldMapper.php
+++ b/lib/Core/Search/Solr/FieldMapper/Content/ContentVisibilityFieldMapper.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\FieldMapper\Content;
+
+use eZ\Publish\SPI\Persistence\Content as SPIContent;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType;
+use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper;
+
+class ContentVisibilityFieldMapper extends ContentFieldMapper
+{
+    public function accept(SPIContent $content)
+    {
+        return true;
+    }
+
+    public function mapFields(SPIContent $content)
+    {
+        return [
+            new Field(
+                'ng_content_visible',
+                !$content->versionInfo->contentInfo->isHidden,
+                new FieldType\BooleanField()
+            ),
+        ];
+    }
+}

--- a/lib/Core/Search/Solr/FieldMapper/Location/LocationVisibilityFieldMapper.php
+++ b/lib/Core/Search/Solr/FieldMapper/Location/LocationVisibilityFieldMapper.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\FieldMapper\Location;
+
+use eZ\Publish\SPI\Persistence\Content\Handler as ContentHandler;
+use eZ\Publish\SPI\Persistence\Content\Location as SPILocation;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType;
+use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper;
+
+class LocationVisibilityFieldMapper extends LocationFieldMapper
+{
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Handler
+     */
+    protected $contentHandler;
+
+    public function __construct(ContentHandler $contentHandler)
+    {
+        $this->contentHandler = $contentHandler;
+    }
+
+    public function accept(SPILocation $location)
+    {
+        return true;
+    }
+
+    public function mapFields(SPILocation $location)
+    {
+        $contentInfo = $this->contentHandler->loadContentInfo($location->contentId);
+
+        return [
+            new Field(
+                'ng_location_visible',
+                !$location->hidden && !$location->invisible && !$contentInfo->isHidden,
+                new FieldType\BooleanField()
+            ),
+        ];
+    }
+}

--- a/lib/Core/Search/Solr/Query/Content/CriterionVisitor/Visible.php
+++ b/lib/Core/Search/Solr/Query/Content/CriterionVisitor/Visible.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Content\CriterionVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\Visible as VisibleCriterion;
+
+class Visible extends CriterionVisitor
+{
+    public function canVisit(Criterion $criterion)
+    {
+        return $criterion instanceof VisibleCriterion;
+    }
+
+    public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null)
+    {
+        $isVisible = $criterion->value[0];
+
+        return 'ng_content_visible_b:' . ($isVisible ? 'true' : 'false');
+    }
+}

--- a/lib/Core/Search/Solr/Query/Location/CriterionVisitor/Visible.php
+++ b/lib/Core/Search/Solr/Query/Location/CriterionVisitor/Visible.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Location\CriterionVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\Visible as VisibleCriterion;
+
+class Visible extends CriterionVisitor
+{
+    public function canVisit(Criterion $criterion)
+    {
+        return $criterion instanceof VisibleCriterion;
+    }
+
+    public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null)
+    {
+        $isVisible = $criterion->value[0];
+
+        return 'ng_location_visible:' . ($isVisible ? 'true' : 'false');
+    }
+}

--- a/lib/Core/Search/Solr/Query/Location/CriterionVisitor/Visible.php
+++ b/lib/Core/Search/Solr/Query/Location/CriterionVisitor/Visible.php
@@ -19,6 +19,6 @@ class Visible extends CriterionVisitor
     {
         $isVisible = $criterion->value[0];
 
-        return 'ng_location_visible:' . ($isVisible ? 'true' : 'false');
+        return 'ng_location_visible_b:' . ($isVisible ? 'true' : 'false');
     }
 }

--- a/lib/Resources/config/search/legacy.yml
+++ b/lib/Resources/config/search/legacy.yml
@@ -73,3 +73,19 @@ services:
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+
+    netgen.search.legacy.query.content.criterion_visitor.visible:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Legacy\Query\Content\CriterionHandler\Visible
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
+        arguments:
+            - '@ezpublish.persistence.connection'
+        tags:
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
+
+    netgen.search.legacy.query.location.criterion_visitor.visible:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Legacy\Query\Location\CriterionHandler\Visible
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
+        arguments:
+            - '@ezpublish.persistence.connection'
+        tags:
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}

--- a/lib/Resources/config/search/solr/criterion_visitors.yml
+++ b/lib/Resources/config/search/solr/criterion_visitors.yml
@@ -42,3 +42,13 @@ services:
             - '@ezpublish.search.solr.query.location.criterion_visitor.aggregate'
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
+
+    netgen.search.solr.query.content.criterion_visitor.visible:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Content\CriterionVisitor\Visible
+        tags:
+            - { name: ezpublish.search.solr.query.content.criterion_visitor }
+
+    netgen.search.solr.query.location.criterion_visitor.visible:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Location\CriterionVisitor\Visible
+        tags:
+            - { name: ezpublish.search.solr.query.location.criterion_visitor }

--- a/lib/Resources/config/search/solr/field_mappers.yml
+++ b/lib/Resources/config/search/solr/field_mappers.yml
@@ -6,4 +6,16 @@ services:
             - '@ezpublish.search.common.field_name_generator'
             - '@ezpublish.persistence.field_type_registry'
         tags:
-            - {name: ezpublish.search.solr.field_mapper.block_translation}
+            - { name: ezpublish.search.solr.field_mapper.block_translation }
+
+    netgen.search.solr.field_mapper.content.visibility:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\FieldMapper\Content\ContentVisibilityFieldMapper
+        tags:
+            - { name: ezpublish.search.solr.field_mapper.content }
+
+    netgen.search.solr.field_mapper.location.visibility:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\FieldMapper\Location\LocationVisibilityFieldMapper
+        arguments:
+            - '@ezpublish.spi.persistence.content_handler'
+        tags:
+            - { name: ezpublish.search.solr.field_mapper.location }

--- a/tests/lib/Integration/API/VisibleCriterionTest.php
+++ b/tests/lib/Integration/API/VisibleCriterionTest.php
@@ -1,0 +1,713 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\Tests\Integration\API;
+
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeIdentifier;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentId;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Id as LocationId;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\Visible;
+
+class VisibleCriterionTest extends BaseTest
+{
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testFindVisibleContent(): void
+    {
+        $repository = $this->getRepository();
+        $searchService = $repository->getSearchService();
+        /** @var $contentA \eZ\Publish\API\Repository\Values\Content\Content */
+        /** @var $contentB \eZ\Publish\API\Repository\Values\Content\Content */
+        [$contentA, $contentB] = $this->prepareTestFixtures();
+        $this->refreshSearch($repository);
+
+        $searchResultVisible = $searchService->findContent($this->getContentQuery(true));
+
+        $this->assertSame(2, $searchResultVisible->totalCount);
+        /** @var $content1 \eZ\Publish\API\Repository\Values\Content\Content */
+        /** @var $content2 \eZ\Publish\API\Repository\Values\Content\Content */
+        $content1 = $searchResultVisible->searchHits[0]->valueObject;
+        $content2 = $searchResultVisible->searchHits[1]->valueObject;
+        $this->assertSame($contentA->id, $content1->id);
+        $this->assertSame($contentB->id, $content2->id);
+
+        $searchResultNotVisible = $searchService->findContent($this->getContentQuery(false));
+
+        $this->assertSame(0, $searchResultNotVisible->totalCount);
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testFindHiddenContent()
+    {
+        $repository = $this->getRepository();
+        $searchService = $repository->getSearchService();
+        $contentService = $repository->getContentService();
+        /** @var $contentA \eZ\Publish\API\Repository\Values\Content\Content */
+        /** @var $contentB \eZ\Publish\API\Repository\Values\Content\Content */
+        [$contentA, $contentB] = $this->prepareTestFixtures();
+
+        $contentService->hideContent($contentA->contentInfo);
+        $this->refreshSearch($repository);
+
+        $searchResultNotVisible = $searchService->findContent($this->getContentQuery(false));
+
+        $this->assertSame(1, $searchResultNotVisible->totalCount);
+        /** @var $content1 \eZ\Publish\API\Repository\Values\Content\Content */
+        $content1 = $searchResultNotVisible->searchHits[0]->valueObject;
+        $this->assertSame($contentA->id, $content1->id);
+
+        $searchResultVisible = $searchService->findContent($this->getContentQuery(true));
+
+        $this->assertSame(1, $searchResultVisible->totalCount);
+        /** @var $content2 \eZ\Publish\API\Repository\Values\Content\Content */
+        $content2 = $searchResultVisible->searchHits[0]->valueObject;
+        $this->assertSame($contentB->id, $content2->id);
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testFindVisibleLocation()
+    {
+        $repository = $this->getRepository();
+        $searchService = $repository->getSearchService();
+        /** @var $contentA \eZ\Publish\API\Repository\Values\Content\Content */
+        /** @var $contentB \eZ\Publish\API\Repository\Values\Content\Content */
+        [$contentA, $contentB] = $this->prepareTestFixtures();
+        $this->refreshSearch($repository);
+
+        $searchResultVisible = $searchService->findLocations($this->getLocationQuery(true));
+
+        $this->assertSame(2, $searchResultVisible->totalCount);
+        /** @var $location1 \eZ\Publish\API\Repository\Values\Content\Location */
+        /** @var $location2 \eZ\Publish\API\Repository\Values\Content\Location */
+        $location1 = $searchResultVisible->searchHits[0]->valueObject;
+        $location2 = $searchResultVisible->searchHits[1]->valueObject;
+        $this->assertSame($contentA->contentInfo->mainLocationId, $location1->id);
+        $this->assertSame($contentB->contentInfo->mainLocationId, $location2->id);
+
+        $searchResultNotVisible = $searchService->findLocations($this->getLocationQuery(false));
+
+        $this->assertSame(0, $searchResultNotVisible->totalCount);
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testFindHiddenLocation()
+    {
+        $repository = $this->getRepository();
+        $searchService = $repository->getSearchService();
+        $locationService = $repository->getLocationService();
+        /** @var $contentA \eZ\Publish\API\Repository\Values\Content\Content */
+        /** @var $contentB \eZ\Publish\API\Repository\Values\Content\Content */
+        [$contentA, $contentB] = $this->prepareTestFixtures();
+
+        $locationB = $locationService->loadLocation($contentB->contentInfo->mainLocationId);
+        $locationService->hideLocation($locationB);
+        $this->refreshSearch($repository);
+
+        $searchResultNotVisible = $searchService->findLocations($this->getLocationQuery(false));
+
+        $this->assertSame(1, $searchResultNotVisible->totalCount);
+        /** @var $location2 \eZ\Publish\API\Repository\Values\Content\Location */
+        $location2 = $searchResultNotVisible->searchHits[0]->valueObject;
+        $this->assertSame($contentB->contentInfo->mainLocationId, $location2->id);
+
+        $searchResultVisible = $searchService->findLocations($this->getLocationQuery(true));
+
+        $this->assertSame(1, $searchResultVisible->totalCount);
+        /** @var $location1 \eZ\Publish\API\Repository\Values\Content\Location */
+        $location1 = $searchResultVisible->searchHits[0]->valueObject;
+        $this->assertSame($contentA->contentInfo->mainLocationId, $location1->id);
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testFindInvisibleLocation()
+    {
+        $repository = $this->getRepository();
+        $searchService = $repository->getSearchService();
+        $locationService = $repository->getLocationService();
+        /** @var $contentA \eZ\Publish\API\Repository\Values\Content\Content */
+        /** @var $contentB \eZ\Publish\API\Repository\Values\Content\Content */
+        [$contentA, $contentB] = $this->prepareTestFixtures();
+
+        $locationA = $locationService->loadLocation($contentA->contentInfo->mainLocationId);
+        $locationService->hideLocation($locationA);
+        $this->refreshSearch($repository);
+
+        $searchResultNotVisible = $searchService->findLocations($this->getLocationQuery(false));
+
+        $this->assertSame(2, $searchResultNotVisible->totalCount);
+        /** @var $location1 \eZ\Publish\API\Repository\Values\Content\Location */
+        /** @var $location2 \eZ\Publish\API\Repository\Values\Content\Location */
+        $location1 = $searchResultNotVisible->searchHits[0]->valueObject;
+        $location2 = $searchResultNotVisible->searchHits[1]->valueObject;
+        $this->assertSame($contentA->contentInfo->mainLocationId, $location1->id);
+        $this->assertSame($contentB->contentInfo->mainLocationId, $location2->id);
+
+        $searchResultVisible = $searchService->findLocations($this->getLocationQuery(true));
+
+        $this->assertSame(0, $searchResultVisible->totalCount);
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testFindLocationHiddenContent()
+    {
+        $repository = $this->getRepository();
+        $searchService = $repository->getSearchService();
+        $contentService = $repository->getContentService();
+        /** @var $contentA \eZ\Publish\API\Repository\Values\Content\Content */
+        /** @var $contentB \eZ\Publish\API\Repository\Values\Content\Content */
+        [$contentA, $contentB] = $this->prepareTestFixtures();
+
+        $contentService->hideContent($contentB->contentInfo);
+        $this->refreshSearch($repository);
+
+        $searchResultNotVisible = $searchService->findLocations($this->getLocationQuery(false));
+
+        $this->assertSame(1, $searchResultNotVisible->totalCount);
+        /** @var $location2 \eZ\Publish\API\Repository\Values\Content\Location */
+        $location2 = $searchResultNotVisible->searchHits[0]->valueObject;
+        $this->assertSame($contentB->contentInfo->mainLocationId, $location2->id);
+
+        $searchResultVisible = $searchService->findLocations($this->getLocationQuery(true));
+
+        $this->assertSame(1, $searchResultVisible->totalCount);
+        /** @var $location1 \eZ\Publish\API\Repository\Values\Content\Location */
+        $location1 = $searchResultVisible->searchHits[0]->valueObject;
+        $this->assertSame($contentA->contentInfo->mainLocationId, $location1->id);
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testFindLocationHiddenParentContent()
+    {
+        $repository = $this->getRepository();
+        $searchService = $repository->getSearchService();
+        $contentService = $repository->getContentService();
+        /** @var $contentA \eZ\Publish\API\Repository\Values\Content\Content */
+        /** @var $contentB \eZ\Publish\API\Repository\Values\Content\Content */
+        [$contentA, $contentB] = $this->prepareTestFixtures();
+
+        $contentService->hideContent($contentA->contentInfo);
+        $this->refreshSearch($repository);
+
+        $searchResultNotVisible = $searchService->findLocations($this->getLocationQuery(false));
+
+        $this->assertSame(2, $searchResultNotVisible->totalCount);
+        /** @var $location1 \eZ\Publish\API\Repository\Values\Content\Location */
+        /** @var $location2 \eZ\Publish\API\Repository\Values\Content\Location */
+        $location1 = $searchResultNotVisible->searchHits[0]->valueObject;
+        $location2 = $searchResultNotVisible->searchHits[1]->valueObject;
+        $this->assertSame($contentA->contentInfo->mainLocationId, $location1->id);
+        $this->assertSame($contentB->contentInfo->mainLocationId, $location2->id);
+
+        $searchResultVisible = $searchService->findLocations($this->getLocationQuery(true));
+
+        $this->assertSame(0, $searchResultVisible->totalCount);
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testFindLocationHiddenParentContentReveal()
+    {
+        $repository = $this->getRepository();
+        $searchService = $repository->getSearchService();
+        $contentService = $repository->getContentService();
+        /** @var $contentA \eZ\Publish\API\Repository\Values\Content\Content */
+        /** @var $contentB \eZ\Publish\API\Repository\Values\Content\Content */
+        [$contentA, $contentB] = $this->prepareTestFixtures();
+
+        $contentService->hideContent($contentA->contentInfo);
+        $contentService->revealContent($contentA->contentInfo);
+        $this->refreshSearch($repository);
+
+        $searchResultNotVisible = $searchService->findLocations($this->getLocationQuery(false));
+
+        $this->assertSame(0, $searchResultNotVisible->totalCount);
+
+        $searchResultVisible = $searchService->findLocations($this->getLocationQuery(true));
+
+        $this->assertSame(2, $searchResultVisible->totalCount);
+        /** @var $location1 \eZ\Publish\API\Repository\Values\Content\Location */
+        /** @var $location2 \eZ\Publish\API\Repository\Values\Content\Location */
+        $location1 = $searchResultVisible->searchHits[0]->valueObject;
+        $location2 = $searchResultVisible->searchHits[1]->valueObject;
+        $this->assertSame($contentA->contentInfo->mainLocationId, $location1->id);
+        $this->assertSame($contentB->contentInfo->mainLocationId, $location2->id);
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testFindInvisibleParentLocationHiddenParentContentReveal()
+    {
+        $repository = $this->getRepository();
+        $searchService = $repository->getSearchService();
+        $contentService = $repository->getContentService();
+        $locationService = $repository->getLocationService();
+        /** @var $contentA \eZ\Publish\API\Repository\Values\Content\Content */
+        /** @var $contentB \eZ\Publish\API\Repository\Values\Content\Content */
+        [$contentA, $contentB] = $this->prepareTestFixtures();
+
+        $locationA = $locationService->loadLocation($contentA->contentInfo->mainLocationId);
+        $locationService->hideLocation($locationA);
+        $contentService->hideContent($contentA->contentInfo);
+        $contentService->revealContent($contentA->contentInfo);
+        $this->refreshSearch($repository);
+
+        $searchResultNotVisible = $searchService->findLocations($this->getLocationQuery(false));
+
+        $this->assertSame(2, $searchResultNotVisible->totalCount);
+        /** @var $location1 \eZ\Publish\API\Repository\Values\Content\Location */
+        /** @var $location2 \eZ\Publish\API\Repository\Values\Content\Location */
+        $location1 = $searchResultNotVisible->searchHits[0]->valueObject;
+        $location2 = $searchResultNotVisible->searchHits[1]->valueObject;
+        $this->assertSame($contentA->contentInfo->mainLocationId, $location1->id);
+        $this->assertSame($contentB->contentInfo->mainLocationId, $location2->id);
+
+        $searchResultVisible = $searchService->findLocations($this->getLocationQuery(true));
+
+        $this->assertSame(0, $searchResultVisible->totalCount);
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testFindInvisibleChildLocationHiddenParentContentReveal()
+    {
+        $repository = $this->getRepository();
+        $searchService = $repository->getSearchService();
+        $contentService = $repository->getContentService();
+        $locationService = $repository->getLocationService();
+        /** @var $contentA \eZ\Publish\API\Repository\Values\Content\Content */
+        /** @var $contentB \eZ\Publish\API\Repository\Values\Content\Content */
+        [$contentA, $contentB] = $this->prepareTestFixtures();
+
+        $locationB = $locationService->loadLocation($contentB->contentInfo->mainLocationId);
+        $locationService->hideLocation($locationB);
+        $contentService->hideContent($contentA->contentInfo);
+        $contentService->revealContent($contentA->contentInfo);
+        $this->refreshSearch($repository);
+
+        $searchResultNotVisible = $searchService->findLocations($this->getLocationQuery(false));
+
+        $this->assertSame(1, $searchResultNotVisible->totalCount);
+        /** @var $location2 \eZ\Publish\API\Repository\Values\Content\Location */
+        $location2 = $searchResultNotVisible->searchHits[0]->valueObject;
+        $this->assertSame($contentB->contentInfo->mainLocationId, $location2->id);
+
+        $searchResultVisible = $searchService->findLocations($this->getLocationQuery(true));
+
+        $this->assertSame(1, $searchResultVisible->totalCount);
+        /** @var $location1 \eZ\Publish\API\Repository\Values\Content\Location */
+        $location1 = $searchResultVisible->searchHits[0]->valueObject;
+        $this->assertSame($contentA->contentInfo->mainLocationId, $location1->id);
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testFindVisibleChildAdditionalLocationHiddenParentContent()
+    {
+        $repository = $this->getRepository();
+        $searchService = $repository->getSearchService();
+        $contentService = $repository->getContentService();
+        $locationService = $repository->getLocationService();
+        /** @var $contentA \eZ\Publish\API\Repository\Values\Content\Content */
+        /** @var $contentB \eZ\Publish\API\Repository\Values\Content\Content */
+        [$contentA, $contentB] = $this->prepareTestFixtures();
+
+        $locationCreateStruct = $locationService->newLocationCreateStruct(2);
+        $additionalLocation = $locationService->createLocation($contentB->contentInfo, $locationCreateStruct);
+        $contentService->hideContent($contentA->contentInfo);
+        $this->refreshSearch($repository);
+
+        $searchResultNotVisible = $searchService->findLocations($this->getLocationQuery(false));
+
+        $this->assertSame(2, $searchResultNotVisible->totalCount);
+        /** @var $location1 \eZ\Publish\API\Repository\Values\Content\Location */
+        /** @var $location2 \eZ\Publish\API\Repository\Values\Content\Location */
+        $location1 = $searchResultNotVisible->searchHits[0]->valueObject;
+        $location2 = $searchResultNotVisible->searchHits[1]->valueObject;
+        $this->assertSame($contentA->contentInfo->mainLocationId, $location1->id);
+        $this->assertSame($contentB->contentInfo->mainLocationId, $location2->id);
+
+        $searchResultVisible = $searchService->findLocations($this->getLocationQuery(true));
+
+        $this->assertSame(1, $searchResultVisible->totalCount);
+        /** @var $location3 \eZ\Publish\API\Repository\Values\Content\Location */
+        $location3 = $searchResultVisible->searchHits[0]->valueObject;
+        $this->assertSame($additionalLocation->id, $location3->id);
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testFindVisibleChildAdditionalLocationHiddenParentContentVariant()
+    {
+        $repository = $this->getRepository();
+        $searchService = $repository->getSearchService();
+        $contentService = $repository->getContentService();
+        $locationService = $repository->getLocationService();
+        /** @var $contentA \eZ\Publish\API\Repository\Values\Content\Content */
+        /** @var $contentB \eZ\Publish\API\Repository\Values\Content\Content */
+        [$contentA, $contentB] = $this->prepareTestFixtures();
+
+        $contentService->hideContent($contentA->contentInfo);
+        $locationCreateStruct = $locationService->newLocationCreateStruct(2);
+        $additionalLocation = $locationService->createLocation($contentB->contentInfo, $locationCreateStruct);
+        $this->refreshSearch($repository);
+
+        $searchResultNotVisible = $searchService->findLocations($this->getLocationQuery(false));
+
+        $this->assertSame(2, $searchResultNotVisible->totalCount);
+        /** @var $location1 \eZ\Publish\API\Repository\Values\Content\Location */
+        /** @var $location2 \eZ\Publish\API\Repository\Values\Content\Location */
+        $location1 = $searchResultNotVisible->searchHits[0]->valueObject;
+        $location2 = $searchResultNotVisible->searchHits[1]->valueObject;
+        $this->assertSame($contentA->contentInfo->mainLocationId, $location1->id);
+        $this->assertSame($contentB->contentInfo->mainLocationId, $location2->id);
+
+        $searchResultVisible = $searchService->findLocations($this->getLocationQuery(true));
+
+        $this->assertSame(1, $searchResultVisible->totalCount);
+        /** @var $location3 \eZ\Publish\API\Repository\Values\Content\Location */
+        $location3 = $searchResultVisible->searchHits[0]->valueObject;
+        $this->assertSame($additionalLocation->id, $location3->id);
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testFindInvisibleChildAdditionalLocationHiddenChildContent()
+    {
+        $repository = $this->getRepository();
+        $searchService = $repository->getSearchService();
+        $contentService = $repository->getContentService();
+        $locationService = $repository->getLocationService();
+        /** @var $contentA \eZ\Publish\API\Repository\Values\Content\Content */
+        /** @var $contentB \eZ\Publish\API\Repository\Values\Content\Content */
+        [$contentA, $contentB] = $this->prepareTestFixtures();
+
+        $locationCreateStruct = $locationService->newLocationCreateStruct(2);
+        $additionalLocation = $locationService->createLocation($contentB->contentInfo, $locationCreateStruct);
+        $contentService->hideContent($contentB->contentInfo);
+        $this->refreshSearch($repository);
+
+        $searchResultNotVisible = $searchService->findLocations($this->getLocationQuery(false));
+
+        $this->assertSame(2, $searchResultNotVisible->totalCount);
+        /** @var $location2 \eZ\Publish\API\Repository\Values\Content\Location */
+        /** @var $location3 \eZ\Publish\API\Repository\Values\Content\Location */
+        $location2 = $searchResultNotVisible->searchHits[0]->valueObject;
+        $location3 = $searchResultNotVisible->searchHits[1]->valueObject;
+        $this->assertSame($contentB->contentInfo->mainLocationId, $location2->id);
+        $this->assertSame($additionalLocation->id, $location3->id);
+
+        $searchResultVisible = $searchService->findLocations($this->getLocationQuery(true));
+
+        $this->assertSame(1, $searchResultVisible->totalCount);
+        /** @var $location1 \eZ\Publish\API\Repository\Values\Content\Location */
+        $location1 = $searchResultVisible->searchHits[0]->valueObject;
+        $this->assertSame($contentA->contentInfo->mainLocationId, $location1->id);
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testFindInvisibleChildAdditionalLocationHiddenChildContentVariant()
+    {
+        $repository = $this->getRepository();
+        $searchService = $repository->getSearchService();
+        $contentService = $repository->getContentService();
+        $locationService = $repository->getLocationService();
+        /** @var $contentA \eZ\Publish\API\Repository\Values\Content\Content */
+        /** @var $contentB \eZ\Publish\API\Repository\Values\Content\Content */
+        [$contentA, $contentB] = $this->prepareTestFixtures();
+
+        $contentService->hideContent($contentB->contentInfo);
+        $locationCreateStruct = $locationService->newLocationCreateStruct(2);
+        $additionalLocation = $locationService->createLocation($contentB->contentInfo, $locationCreateStruct);
+        $this->refreshSearch($repository);
+
+        $searchResultNotVisible = $searchService->findLocations($this->getLocationQuery(false));
+
+        $this->assertSame(2, $searchResultNotVisible->totalCount);
+        /** @var $location2 \eZ\Publish\API\Repository\Values\Content\Location */
+        /** @var $location3 \eZ\Publish\API\Repository\Values\Content\Location */
+        $location2 = $searchResultNotVisible->searchHits[0]->valueObject;
+        $location3 = $searchResultNotVisible->searchHits[1]->valueObject;
+        $this->assertSame($contentB->contentInfo->mainLocationId, $location2->id);
+        $this->assertSame($additionalLocation->id, $location3->id);
+
+        $searchResultVisible = $searchService->findLocations($this->getLocationQuery(true));
+
+        $this->assertSame(1, $searchResultVisible->totalCount);
+        /** @var $location1 \eZ\Publish\API\Repository\Values\Content\Location */
+        $location1 = $searchResultVisible->searchHits[0]->valueObject;
+        $this->assertSame($contentA->contentInfo->mainLocationId, $location1->id);
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testFindInvisibleChildAdditionalSubtreeHiddenChildContent()
+    {
+        $repository = $this->getRepository();
+        $searchService = $repository->getSearchService();
+        $contentService = $repository->getContentService();
+        $locationService = $repository->getLocationService();
+        /** @var $contentA \eZ\Publish\API\Repository\Values\Content\Content */
+        /** @var $contentB \eZ\Publish\API\Repository\Values\Content\Content */
+        [$contentA, $contentB] = $this->prepareTestFixtures();
+
+        $contentService->hideContent($contentB->contentInfo);
+        $locationCreateStruct = $locationService->newLocationCreateStruct(2);
+        $additionalLocation1 = $locationService->createLocation($contentB->contentInfo, $locationCreateStruct);
+        $locationCreateStruct = $locationService->newLocationCreateStruct($additionalLocation1->id);
+        $additionalLocation2 = $locationService->createLocation($contentA->contentInfo, $locationCreateStruct);
+        $this->refreshSearch($repository);
+
+        $searchResultNotVisible = $searchService->findLocations($this->getLocationQuery(false));
+
+        $this->assertSame(3, $searchResultNotVisible->totalCount);
+        /** @var $location2 \eZ\Publish\API\Repository\Values\Content\Location */
+        /** @var $location3 \eZ\Publish\API\Repository\Values\Content\Location */
+        /** @var $location4 \eZ\Publish\API\Repository\Values\Content\Location */
+        $location2 = $searchResultNotVisible->searchHits[0]->valueObject;
+        $location3 = $searchResultNotVisible->searchHits[1]->valueObject;
+        $location4 = $searchResultNotVisible->searchHits[2]->valueObject;
+        $this->assertSame($contentB->contentInfo->mainLocationId, $location2->id);
+        $this->assertSame($additionalLocation1->id, $location3->id);
+        $this->assertSame($additionalLocation2->id, $location4->id);
+
+        $searchResultVisible = $searchService->findLocations($this->getLocationQuery(true));
+
+        $this->assertSame(1, $searchResultVisible->totalCount);
+        /** @var $location1 \eZ\Publish\API\Repository\Values\Content\Location */
+        $location1 = $searchResultVisible->searchHits[0]->valueObject;
+        $this->assertSame($contentA->contentInfo->mainLocationId, $location1->id);
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testFindInvisibleChildAdditionalSubtreeHiddenChildContentVariant()
+    {
+        $repository = $this->getRepository();
+        $searchService = $repository->getSearchService();
+        $contentService = $repository->getContentService();
+        $locationService = $repository->getLocationService();
+        /** @var $contentA \eZ\Publish\API\Repository\Values\Content\Content */
+        /** @var $contentB \eZ\Publish\API\Repository\Values\Content\Content */
+        [$contentA, $contentB] = $this->prepareTestFixtures();
+
+        $locationCreateStruct = $locationService->newLocationCreateStruct(2);
+        $additionalLocation1 = $locationService->createLocation($contentB->contentInfo, $locationCreateStruct);
+        $locationCreateStruct = $locationService->newLocationCreateStruct($additionalLocation1->id);
+        $additionalLocation2 = $locationService->createLocation($contentA->contentInfo, $locationCreateStruct);
+        $contentService->hideContent($contentB->contentInfo);
+        $this->refreshSearch($repository);
+
+        $searchResultNotVisible = $searchService->findLocations($this->getLocationQuery(false));
+
+        $this->assertSame(3, $searchResultNotVisible->totalCount);
+        /** @var $location2 \eZ\Publish\API\Repository\Values\Content\Location */
+        /** @var $location3 \eZ\Publish\API\Repository\Values\Content\Location */
+        /** @var $location4 \eZ\Publish\API\Repository\Values\Content\Location */
+        $location2 = $searchResultNotVisible->searchHits[0]->valueObject;
+        $location3 = $searchResultNotVisible->searchHits[1]->valueObject;
+        $location4 = $searchResultNotVisible->searchHits[2]->valueObject;
+        $this->assertSame($contentB->contentInfo->mainLocationId, $location2->id);
+        $this->assertSame($additionalLocation1->id, $location3->id);
+        $this->assertSame($additionalLocation2->id, $location4->id);
+
+        $searchResultVisible = $searchService->findLocations($this->getLocationQuery(true));
+
+        $this->assertSame(1, $searchResultVisible->totalCount);
+        /** @var $location1 \eZ\Publish\API\Repository\Values\Content\Location */
+        $location1 = $searchResultVisible->searchHits[0]->valueObject;
+        $this->assertSame($contentA->contentInfo->mainLocationId, $location1->id);
+    }
+
+    protected function getContentQuery(bool $visible): Query
+    {
+        return new Query([
+            'filter' => new LogicalAnd([
+                new ContentTypeIdentifier('stump'),
+                new Visible($visible),
+            ]),
+            'sortClauses' => [
+                new ContentId(Query::SORT_ASC),
+            ],
+        ]);
+    }
+
+    protected function getLocationQuery(bool $visible): LocationQuery
+    {
+        return new LocationQuery([
+            'filter' => new LogicalAnd([
+                new ContentTypeIdentifier('stump'),
+                new Visible($visible),
+            ]),
+            'sortClauses' => [
+                new LocationId(Query::SORT_ASC),
+            ],
+        ]);
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function prepareTestFixtures()
+    {
+        $repository = $this->getRepository();
+        $contentService = $repository->getContentService();
+        $contentTypeService = $repository->getContentTypeService();
+        $locationService = $repository->getLocationService();
+
+        $contentTypeGroups = $contentTypeService->loadContentTypeGroups();
+        $contentTypeCreateStruct = $contentTypeService->newContentTypeCreateStruct('stump');
+        $contentTypeCreateStruct->mainLanguageCode = 'eng-GB';
+        $contentTypeCreateStruct->names = ['eng-GB' => 'Stump type'];
+        $fieldDefinitionCreateStruct = $contentTypeService->newFieldDefinitionCreateStruct('width', 'ezinteger');
+        $contentTypeCreateStruct->addFieldDefinition($fieldDefinitionCreateStruct);
+        $contentTypeDraft = $contentTypeService->createContentType($contentTypeCreateStruct, [reset($contentTypeGroups)]);
+        $contentTypeService->publishContentTypeDraft($contentTypeDraft);
+        $contentType = $contentTypeService->loadContentTypeByIdentifier('stump');
+
+        $locationCreateStruct = $locationService->newLocationCreateStruct(2);
+
+        $contentCreateStruct = $contentService->newContentCreateStruct($contentType, 'eng-GB');
+        $contentCreateStruct->setField('width', 135);
+        $contentDraft = $contentService->createContent($contentCreateStruct, [$locationCreateStruct]);
+        $contentA = $contentService->publishVersion($contentDraft->versionInfo);
+
+        $mainLocation = $contentA->contentInfo->getMainLocation();
+        $locationCreateStruct = $locationService->newLocationCreateStruct($mainLocation->id);
+
+        $contentCreateStruct = $contentService->newContentCreateStruct($contentType, 'eng-GB');
+        $contentCreateStruct->setField('width', 235);
+        $contentDraft = $contentService->createContent($contentCreateStruct, [$locationCreateStruct]);
+        $contentB = $contentService->publishVersion($contentDraft->versionInfo);
+
+        return [$contentA, $contentB];
+    }
+}


### PR DESCRIPTION
This is needed for Site API v4 for eZ Platform v3, in order to support Content and Location visibility.

Since it's missing in Repository API, a new `Visible` criterion is added, supported in both Content and Location search. In Content search it matches Content visibility and in Location search it matches Location visibility. Visitors are implemented for both Solr and Legacy search engines, and Solr search engine also required field mappers (indexing plugins).

Location is defined as visible if it's not explicitly hidden itself AND not hidden by ancestor (aka invisible) AND it's Content is not hidden. If any of these conditions is not true, Location will not be visible.