### PR TITLE
NGSTACK-361: add ContentId and LocationId criteria with extended operator support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
         - php: 7.1
           env: TEST_CONFIG="phpunit-integration-solr.xml" SOLR_VERSION="6.6.5" CORES_SETUP="single" SOLR_CORES="collection1"
         - php: 7.1
-          env: TEST_CONFIG="phpunit-integration-solr.xml" SOLR_VERSION="6.6.5" CORES_SETUP="shared" COMPOSER_REQUIRE="ezsystems/ezpublish-kernel:~6.13.6@dev"
+          env: TEST_CONFIG="phpunit-integration-solr.xml" SOLR_VERSION="6.6.5" CORES_SETUP="shared"
         - php: 7.2
           env: TEST_CONFIG="phpunit-integration-solr.xml" SOLR_VERSION="6.6.5" CORES_SETUP="dedicated"
         - php: 7.2

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Only a list of features is provided here, see
 [documentation](https://netgen-ezplatform-search-extra.readthedocs.io)
 for more details.
 
+- `ContentId` and `LocationId` criteria with support for range operators:
+
+  Supported operators are: `EQ`, `IN`, `GT`, `GTE`, `LT`, `LTE`, `BETWEEN`.
+
 - [Spellcheck suggestions support](https://docs.netgen.io/projects/search-extra/en/latest/reference/spellcheck_suggestions.html) (`solr`)
 
 - [`CustomField`](https://github.com/netgen/ezplatform-search-extra/blob/master/lib/API/Values/Content/Query/SortClause/CustomField.php) sort clause (`solr`)

--- a/bin/.travis/init_solr.sh
+++ b/bin/.travis/init_solr.sh
@@ -9,6 +9,7 @@ default_cores[1]='core1'
 default_cores[2]='core2'
 default_cores[3]='core3'
 default_cores[4]='core4'
+default_cores[5]='core5'
 
 SOLR_PORT=${SOLR_PORT:-8983}
 SOLR_VERSION=${SOLR_VERSION:-6.6.5}

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "ezsystems/ezpublish-kernel": "^5.4.11||^6.0||^7.0||^8.0",
+        "ezsystems/ezpublish-kernel": "^7.5.8||^8.0",
         "ext-json": "*",
         "ext-dom": "*"
     },

--- a/lib/API/Values/Content/Query/Criterion/ContentId.php
+++ b/lib/API/Values/Content/Query/Criterion/ContentId.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
+
+/**
+ * A criterion that matches Content based on its ID.
+ */
+class ContentId extends Criterion
+{
+    /**
+     * @param string $operator One of the Operator constants
+     * @param int|int[]|string|string[] $value One or more Content IDs that must be matched
+     */
+    public function __construct(string $operator, $value)
+    {
+        parent::__construct(null, $operator, $value);
+    }
+
+    public function getSpecifications(): array
+    {
+        return [
+            new Specifications(Operator::EQ, Specifications::FORMAT_SINGLE, Specifications::TYPE_INTEGER),
+            new Specifications(Operator::IN, Specifications::FORMAT_ARRAY, Specifications::TYPE_INTEGER),
+            new Specifications(Operator::GT, Specifications::FORMAT_SINGLE, Specifications::TYPE_INTEGER),
+            new Specifications(Operator::GTE, Specifications::FORMAT_SINGLE, Specifications::TYPE_INTEGER),
+            new Specifications(Operator::LT, Specifications::FORMAT_SINGLE, Specifications::TYPE_INTEGER),
+            new Specifications(Operator::LTE, Specifications::FORMAT_SINGLE, Specifications::TYPE_INTEGER),
+            new Specifications(Operator::BETWEEN, Specifications::FORMAT_ARRAY, Specifications::TYPE_INTEGER, 2),
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
+     */
+    public static function createFromQueryBuilder($target, $operator, $value)
+    {
+        @trigger_error(
+            'The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.',
+            E_USER_DEPRECATED
+        );
+
+        return new self($operator, $value);
+    }
+}

--- a/lib/API/Values/Content/Query/Criterion/ContentId.php
+++ b/lib/API/Values/Content/Query/Criterion/ContentId.php
@@ -15,12 +15,12 @@ class ContentId extends Criterion
      * @param string $operator One of the Operator constants
      * @param int|int[]|string|string[] $value One or more Content IDs that must be matched
      */
-    public function __construct(string $operator, $value)
+    public function __construct($operator, $value)
     {
         parent::__construct(null, $operator, $value);
     }
 
-    public function getSpecifications(): array
+    public function getSpecifications()
     {
         return [
             new Specifications(Operator::EQ, Specifications::FORMAT_SINGLE, Specifications::TYPE_INTEGER),

--- a/lib/API/Values/Content/Query/Criterion/LocationId.php
+++ b/lib/API/Values/Content/Query/Criterion/LocationId.php
@@ -15,12 +15,12 @@ class LocationId extends Criterion
      * @param string $operator One of the Operator constants
      * @param int|int[]|string|string[] $value One or more Location IDs that must be matched
      */
-    public function __construct(string $operator, $value)
+    public function __construct($operator, $value)
     {
         parent::__construct(null, $operator, $value);
     }
 
-    public function getSpecifications(): array
+    public function getSpecifications()
     {
         return [
             new Specifications(Operator::EQ, Specifications::FORMAT_SINGLE, Specifications::TYPE_INTEGER),

--- a/lib/API/Values/Content/Query/Criterion/LocationId.php
+++ b/lib/API/Values/Content/Query/Criterion/LocationId.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
+
+/**
+ * A criterion that matches Location based on its ID.
+ */
+class LocationId extends Criterion
+{
+    /**
+     * @param string $operator One of the Operator constants
+     * @param int|int[]|string|string[] $value One or more Location IDs that must be matched
+     */
+    public function __construct(string $operator, $value)
+    {
+        parent::__construct(null, $operator, $value);
+    }
+
+    public function getSpecifications(): array
+    {
+        return [
+            new Specifications(Operator::EQ, Specifications::FORMAT_SINGLE, Specifications::TYPE_INTEGER),
+            new Specifications(Operator::IN, Specifications::FORMAT_ARRAY, Specifications::TYPE_INTEGER),
+            new Specifications(Operator::GT, Specifications::FORMAT_SINGLE, Specifications::TYPE_INTEGER),
+            new Specifications(Operator::GTE, Specifications::FORMAT_SINGLE, Specifications::TYPE_INTEGER),
+            new Specifications(Operator::LT, Specifications::FORMAT_SINGLE, Specifications::TYPE_INTEGER),
+            new Specifications(Operator::LTE, Specifications::FORMAT_SINGLE, Specifications::TYPE_INTEGER),
+            new Specifications(Operator::BETWEEN, Specifications::FORMAT_ARRAY, Specifications::TYPE_INTEGER, 2),
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
+     */
+    public static function createFromQueryBuilder($target, $operator, $value)
+    {
+        @trigger_error(
+            'The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.',
+            E_USER_DEPRECATED
+        );
+
+        return new self($operator, $value);
+    }
+}

--- a/lib/Core/Search/Legacy/Query/Common/CriterionHandler/ContentId.php
+++ b/lib/Core/Search/Legacy/Query/Common/CriterionHandler/ContentId.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Legacy\Query\Common\CriterionHandler;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\Core\Persistence\Database\SelectQuery;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\ContentId as ContentIdCriterion;
+use RuntimeException;
+
+/**
+ * @see \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\ContentId
+ */
+final class ContentId extends CriterionHandler
+{
+    public function accept(Criterion $criterion)
+    {
+        return $criterion instanceof ContentIdCriterion;
+    }
+
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $languageSettings
+    ) {
+        $column = $this->dbHandler->quoteColumn('id', 'ezcontentobject');
+
+        switch ($criterion->operator) {
+            case Criterion\Operator::EQ:
+            case Criterion\Operator::IN:
+                return $query->expr->in($column, $criterion->value);
+
+            case Criterion\Operator::GT:
+            case Criterion\Operator::GTE:
+            case Criterion\Operator::LT:
+            case Criterion\Operator::LTE:
+                $operatorFunction = $this->comparatorMap[$criterion->operator];
+
+                return $query->expr->$operatorFunction(
+                    $column,
+                    $query->bindValue(reset($criterion->value))
+                );
+
+            case Criterion\Operator::BETWEEN:
+                return $query->expr->between(
+                    $column,
+                    $query->bindValue($criterion->value[0]),
+                    $query->bindValue($criterion->value[1])
+                );
+
+            default:
+                throw new RuntimeException(
+                    "Unknown operator '{$criterion->operator}' for ContentId criterion handler."
+                );
+        }
+    }
+}

--- a/lib/Core/Search/Legacy/Query/Content/CriterionHandler/LocationId.php
+++ b/lib/Core/Search/Legacy/Query/Content/CriterionHandler/LocationId.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Legacy\Query\Content\CriterionHandler;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\Core\Persistence\Database\SelectQuery;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\LocationId as LocationIdCriterion;
+use RuntimeException;
+
+/**
+ * @see \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\LocationId
+ */
+final class LocationId extends CriterionHandler
+{
+    public function accept(Criterion $criterion)
+    {
+        return $criterion instanceof LocationIdCriterion;
+    }
+
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $languageSettings
+    ) {
+        $column = $this->dbHandler->quoteColumn('node_id');
+        $subSelectQuery = $query->subSelect();
+
+        switch ($criterion->operator) {
+            case Criterion\Operator::EQ:
+            case Criterion\Operator::IN:
+                $expression = $subSelectQuery->expr->in($column, $criterion->value);
+                break;
+
+            case Criterion\Operator::GT:
+            case Criterion\Operator::GTE:
+            case Criterion\Operator::LT:
+            case Criterion\Operator::LTE:
+                $operatorFunction = $this->comparatorMap[$criterion->operator];
+                $expression = $query->expr->$operatorFunction(
+                    $column,
+                    $subSelectQuery->bindValue(reset($criterion->value))
+                );
+                break;
+
+            case Criterion\Operator::BETWEEN:
+                $expression = $query->expr->between(
+                    $column,
+                    $subSelectQuery->bindValue($criterion->value[0]),
+                    $subSelectQuery->bindValue($criterion->value[1])
+                );
+                break;
+
+            default:
+                throw new RuntimeException(
+                    "Unknown operator '{$criterion->operator}' for LocationId criterion handler."
+                );
+        }
+
+        $subSelectQuery
+            ->select(
+                $this->dbHandler->quoteColumn('contentobject_id')
+            )->from(
+                $this->dbHandler->quoteTable('ezcontentobject_tree')
+            )->where($expression);
+
+        return $query->expr->in(
+            $this->dbHandler->quoteColumn('id', 'ezcontentobject'),
+            $subSelectQuery
+        );
+
+    }
+}

--- a/lib/Core/Search/Legacy/Query/Location/CriterionHandler/LocationId.php
+++ b/lib/Core/Search/Legacy/Query/Location/CriterionHandler/LocationId.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Legacy\Query\Location\CriterionHandler;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\Core\Persistence\Database\SelectQuery;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\LocationId as LocationIdCriterion;
+use RuntimeException;
+
+/**
+ * @see \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\LocationId
+ */
+final class LocationId extends CriterionHandler
+{
+    public function accept(Criterion $criterion)
+    {
+        return $criterion instanceof LocationIdCriterion;
+    }
+
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $languageSettings
+    ) {
+        $column = $this->dbHandler->quoteColumn('node_id', 'ezcontentobject_tree');
+
+        switch ($criterion->operator) {
+            case Criterion\Operator::EQ:
+            case Criterion\Operator::IN:
+                return $query->expr->in($column, $criterion->value);
+
+            case Criterion\Operator::GT:
+            case Criterion\Operator::GTE:
+            case Criterion\Operator::LT:
+            case Criterion\Operator::LTE:
+                $operatorFunction = $this->comparatorMap[$criterion->operator];
+
+                return $query->expr->$operatorFunction(
+                    $column,
+                    $query->bindValue(reset($criterion->value))
+                );
+
+            case Criterion\Operator::BETWEEN:
+                return $query->expr->between(
+                    $column,
+                    $query->bindValue($criterion->value[0]),
+                    $query->bindValue($criterion->value[1])
+                );
+
+            default:
+                throw new RuntimeException(
+                    "Unknown operator '{$criterion->operator}' for LocationId criterion handler."
+                );
+        }
+    }
+}

--- a/lib/Core/Search/Solr/FieldMapper/Content/ContentAndLocationIdFieldMapper.php
+++ b/lib/Core/Search/Solr/FieldMapper/Content/ContentAndLocationIdFieldMapper.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\FieldMapper\Content;
+
+use eZ\Publish\SPI\Persistence\Content as SPIContent;
+use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandler;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType\IntegerField;
+use eZ\Publish\SPI\Search\FieldType\MultipleIntegerField;
+use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper;
+
+class ContentAndLocationIdFieldMapper extends ContentFieldMapper
+{
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Location\Handler
+     */
+    protected $locationHandler;
+
+    /**
+     * @param \eZ\Publish\SPI\Persistence\Content\Location\Handler $locationHandler
+     */
+    public function __construct(LocationHandler $locationHandler)
+    {
+        $this->locationHandler = $locationHandler;
+    }
+
+    public function accept(SPIContent $content)
+    {
+        return true;
+    }
+
+    public function mapFields(SPIContent $content)
+    {
+        $locations = $this->locationHandler->loadLocationsByContent($content->versionInfo->contentInfo->id);
+        $locationIds = [];
+
+        foreach ($locations as $location) {
+            $locationIds[] = $location->id;
+        }
+
+        return [
+            new Field(
+                'ng_content_id',
+                $content->versionInfo->contentInfo->id,
+                new IntegerField()
+            ),
+            new Field(
+                'ng_location_id',
+                $locationIds,
+                new MultipleIntegerField()
+            ),
+        ];
+    }
+}

--- a/lib/Core/Search/Solr/FieldMapper/Location/LocationIdFieldMapper.php
+++ b/lib/Core/Search/Solr/FieldMapper/Location/LocationIdFieldMapper.php
@@ -1,0 +1,28 @@
+<?php
+
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\FieldMapper\Location;
+
+use eZ\Publish\SPI\Persistence\Content\Location as SPILocation;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType\IntegerField;
+use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper;
+
+class LocationIdFieldMapper extends LocationFieldMapper
+{
+    public function accept(SPILocation $location)
+    {
+        return true;
+    }
+
+    public function mapFields(SPILocation $location)
+    {
+        return [
+            new Field(
+                'ng_location_id',
+                $location->id,
+                new IntegerField()
+            ),
+        ];
+    }
+}

--- a/lib/Core/Search/Solr/Query/Common/CriterionVisitor/ContentIdBetween.php
+++ b/lib/Core/Search/Solr/Query/Common/CriterionVisitor/ContentIdBetween.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\ContentId as ContentIdCriterion;
+
+/**
+ * Visits the ContentId criterion.
+ *
+ * @see \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\ContentId
+ */
+final class ContentIdBetween extends CriterionVisitor
+{
+    public function canVisit(Criterion $criterion)
+    {
+        return
+            $criterion instanceof ContentIdCriterion
+            && (
+                $criterion->operator === Operator::LT
+                || $criterion->operator === Operator::LTE
+                || $criterion->operator === Operator::GT
+                || $criterion->operator === Operator::GTE
+                || $criterion->operator === Operator::BETWEEN
+            );
+    }
+
+    public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null)
+    {
+        $start = $criterion->value[0];
+        $end = isset($criterion->value[1]) ? $criterion->value[1] : null;
+
+        if ($criterion->operator === Operator::LT || $criterion->operator === Operator::LTE) {
+            $end = $start;
+            $start = null;
+        }
+
+        return 'content_id_id:' . $this->getRange($criterion->operator, $start, $end);
+    }
+}

--- a/lib/Core/Search/Solr/Query/Common/CriterionVisitor/ContentIdBetween.php
+++ b/lib/Core/Search/Solr/Query/Common/CriterionVisitor/ContentIdBetween.php
@@ -37,6 +37,6 @@ final class ContentIdBetween extends CriterionVisitor
             $start = null;
         }
 
-        return 'content_id_id:' . $this->getRange($criterion->operator, $start, $end);
+        return 'ng_content_id_i:' . $this->getRange($criterion->operator, $start, $end);
     }
 }

--- a/lib/Core/Search/Solr/Query/Common/CriterionVisitor/ContentIdIn.php
+++ b/lib/Core/Search/Solr/Query/Common/CriterionVisitor/ContentIdIn.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\ContentId as ContentIdCriterion;
+
+/**
+ * Visits the ContentId criterion.
+ *
+ * @see \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\ContentId
+ */
+final class ContentIdIn extends CriterionVisitor
+{
+    public function canVisit(Criterion $criterion)
+    {
+        return
+            $criterion instanceof ContentIdCriterion
+            && (
+                $criterion->operator  === Operator::IN
+                || $criterion->operator === Operator::EQ
+            );
+    }
+
+    public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null)
+    {
+        $values = array();
+
+        foreach ($criterion->value as $value) {
+            $values[] = 'content_id_id:"' . $value . '"';
+        }
+
+        return '(' . implode(' OR ', $values) . ')';
+    }
+}

--- a/lib/Core/Search/Solr/Query/Common/CriterionVisitor/ContentIdIn.php
+++ b/lib/Core/Search/Solr/Query/Common/CriterionVisitor/ContentIdIn.php
@@ -29,7 +29,7 @@ final class ContentIdIn extends CriterionVisitor
         $values = array();
 
         foreach ($criterion->value as $value) {
-            $values[] = 'content_id_id:"' . $value . '"';
+            $values[] = 'ng_content_id_i:"' . $value . '"';
         }
 
         return '(' . implode(' OR ', $values) . ')';

--- a/lib/Core/Search/Solr/Query/Common/CriterionVisitor/ContentIdIn.php
+++ b/lib/Core/Search/Solr/Query/Common/CriterionVisitor/ContentIdIn.php
@@ -19,7 +19,7 @@ final class ContentIdIn extends CriterionVisitor
         return
             $criterion instanceof ContentIdCriterion
             && (
-                $criterion->operator  === Operator::IN
+                $criterion->operator === Operator::IN
                 || $criterion->operator === Operator::EQ
             );
     }

--- a/lib/Core/Search/Solr/Query/Content/CriterionVisitor/LocationIdBetween.php
+++ b/lib/Core/Search/Solr/Query/Content/CriterionVisitor/LocationIdBetween.php
@@ -38,6 +38,6 @@ class LocationIdBetween extends CriterionVisitor
             $start = null;
         }
 
-        return 'location_id_mid:' . $this->getRange($criterion->operator, $start, $end);
+        return 'ng_location_id_mi:' . $this->getRange($criterion->operator, $start, $end);
     }
 }

--- a/lib/Core/Search/Solr/Query/Content/CriterionVisitor/LocationIdBetween.php
+++ b/lib/Core/Search/Solr/Query/Content/CriterionVisitor/LocationIdBetween.php
@@ -1,0 +1,43 @@
+<?php
+
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Content\CriterionVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\LocationId as LocationIdCriterion;
+
+/**
+ * Visits the LocationId criterion.
+ *
+ * @see \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\LocationId
+ */
+class LocationIdBetween extends CriterionVisitor
+{
+    public function canVisit(Criterion $criterion)
+    {
+        return
+            $criterion instanceof LocationIdCriterion
+            && (
+                $criterion->operator === Operator::LT
+                || $criterion->operator === Operator::LTE
+                || $criterion->operator === Operator::GT
+                || $criterion->operator === Operator::GTE
+                || $criterion->operator === Operator::BETWEEN
+            );
+    }
+
+    public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null)
+    {
+        $start = $criterion->value[0];
+        $end = isset($criterion->value[1]) ? $criterion->value[1] : null;
+
+        if ($criterion->operator === Operator::LT || $criterion->operator === Operator::LTE) {
+            $end = $start;
+            $start = null;
+        }
+
+        return 'location_id_mid:' . $this->getRange($criterion->operator, $start, $end);
+    }
+}

--- a/lib/Core/Search/Solr/Query/Content/CriterionVisitor/LocationIdIn.php
+++ b/lib/Core/Search/Solr/Query/Content/CriterionVisitor/LocationIdIn.php
@@ -30,7 +30,7 @@ class LocationIdIn extends CriterionVisitor
         $values = array();
 
         foreach ($criterion->value as $value) {
-            $values[] = 'location_id_mid:"' . $value . '"';
+            $values[] = 'ng_location_id_mi:"' . $value . '"';
         }
 
         return '(' . implode(' OR ', $values) . ')';

--- a/lib/Core/Search/Solr/Query/Content/CriterionVisitor/LocationIdIn.php
+++ b/lib/Core/Search/Solr/Query/Content/CriterionVisitor/LocationIdIn.php
@@ -1,0 +1,38 @@
+<?php
+
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Content\CriterionVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\LocationId as LocationIdCriterion;
+
+/**
+ * Visits the LocationId criterion.
+ *
+ * @see \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\LocationId
+ */
+class LocationIdIn extends CriterionVisitor
+{
+    public function canVisit(Criterion $criterion)
+    {
+        return
+            $criterion instanceof LocationIdCriterion
+            && (
+                $criterion->operator === Operator::IN
+                || $criterion->operator === Operator::EQ
+            );
+    }
+
+    public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null)
+    {
+        $values = array();
+
+        foreach ($criterion->value as $value) {
+            $values[] = 'location_id_mid:"' . $value . '"';
+        }
+
+        return '(' . implode(' OR ', $values) . ')';
+    }
+}

--- a/lib/Core/Search/Solr/Query/Location/CriterionVisitor/LocationIdBetween.php
+++ b/lib/Core/Search/Solr/Query/Location/CriterionVisitor/LocationIdBetween.php
@@ -1,0 +1,43 @@
+<?php
+
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Location\CriterionVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\LocationId as LocationIdCriterion;
+
+/**
+ * Visits the LocationId criterion.
+ *
+ * @see \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\LocationId
+ */
+class LocationIdBetween extends CriterionVisitor
+{
+    public function canVisit(Criterion $criterion)
+    {
+        return
+            $criterion instanceof LocationIdCriterion
+            && (
+                $criterion->operator === Operator::LT
+                || $criterion->operator === Operator::LTE
+                || $criterion->operator === Operator::GT
+                || $criterion->operator === Operator::GTE
+                || $criterion->operator === Operator::BETWEEN
+            );
+    }
+
+    public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null)
+    {
+        $start = $criterion->value[0];
+        $end = isset($criterion->value[1]) ? $criterion->value[1] : null;
+
+        if ($criterion->operator === Operator::LT || $criterion->operator === Operator::LTE) {
+            $end = $start;
+            $start = null;
+        }
+
+        return 'location_id:' . $this->getRange($criterion->operator, $start, $end);
+    }
+}

--- a/lib/Core/Search/Solr/Query/Location/CriterionVisitor/LocationIdBetween.php
+++ b/lib/Core/Search/Solr/Query/Location/CriterionVisitor/LocationIdBetween.php
@@ -38,6 +38,6 @@ class LocationIdBetween extends CriterionVisitor
             $start = null;
         }
 
-        return 'location_id:' . $this->getRange($criterion->operator, $start, $end);
+        return 'ng_location_id_i:' . $this->getRange($criterion->operator, $start, $end);
     }
 }

--- a/lib/Core/Search/Solr/Query/Location/CriterionVisitor/LocationIdIn.php
+++ b/lib/Core/Search/Solr/Query/Location/CriterionVisitor/LocationIdIn.php
@@ -1,0 +1,38 @@
+<?php
+
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Location\CriterionVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\LocationId as LocationIdCriterion;
+
+/**
+ * Visits the LocationId criterion.
+ *
+ * @see \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\LocationId
+ */
+class LocationIdIn extends CriterionVisitor
+{
+    public function canVisit(Criterion $criterion)
+    {
+        return
+            $criterion instanceof LocationIdCriterion
+            && (
+                $criterion->operator === Operator::IN
+                || $criterion->operator === Operator::EQ
+            );
+    }
+
+    public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null)
+    {
+        $values = array();
+
+        foreach ($criterion->value as $value) {
+            $values[] = 'location_id:"' . $value . '"';
+        }
+
+        return '(' . implode(' OR ', $values) . ')';
+    }
+}

--- a/lib/Core/Search/Solr/Query/Location/CriterionVisitor/LocationIdIn.php
+++ b/lib/Core/Search/Solr/Query/Location/CriterionVisitor/LocationIdIn.php
@@ -30,7 +30,7 @@ class LocationIdIn extends CriterionVisitor
         $values = array();
 
         foreach ($criterion->value as $value) {
-            $values[] = 'location_id:"' . $value . '"';
+            $values[] = 'ng_location_id_i:"' . $value . '"';
         }
 
         return '(' . implode(' OR ', $values) . ')';

--- a/lib/Resources/config/search/legacy.yml
+++ b/lib/Resources/config/search/legacy.yml
@@ -65,3 +65,25 @@ services:
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+
+    netgen.search.legacy.query.common.criterion_visitor.content_id:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Legacy\Query\Common\CriterionHandler\ContentId
+        arguments:
+            - '@ezpublish.api.storage_engine.legacy.dbhandler'
+        tags:
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+
+    netgen.search.legacy.query.content.criterion_visitor.location_id:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Legacy\Query\Content\CriterionHandler\LocationId
+        arguments:
+            - '@ezpublish.api.storage_engine.legacy.dbhandler'
+        tags:
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
+
+    netgen.search.legacy.query.location.criterion_visitor.location_id:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Legacy\Query\Location\CriterionHandler\LocationId
+        arguments:
+            - '@ezpublish.api.storage_engine.legacy.dbhandler'
+        tags:
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}

--- a/lib/Resources/config/search/solr/criterion_visitors.yml
+++ b/lib/Resources/config/search/solr/criterion_visitors.yml
@@ -42,3 +42,33 @@ services:
             - '@ezpublish.search.solr.query.location.criterion_visitor.aggregate'
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
+
+    netgen.search.solr.query.common.criterion_visitor.content_id_in:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor\ContentIdIn
+        tags:
+            - { name: ezpublish.search.solr.query.common.criterion_visitor }
+
+    netgen.search.solr.query.common.criterion_visitor.content_id_between:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor\ContentIdBetween
+        tags:
+            - { name: ezpublish.search.solr.query.common.criterion_visitor }
+
+    netgen.search.solr.query.content.criterion_visitor.location_id_in:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Content\CriterionVisitor\LocationIdIn
+        tags:
+            - { name: ezpublish.search.solr.query.content.criterion_visitor }
+
+    netgen.search.solr.query.content.criterion_visitor.location_id_between:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Content\CriterionVisitor\LocationIdBetween
+        tags:
+            - { name: ezpublish.search.solr.query.content.criterion_visitor }
+
+    netgen.search.solr.query.location.criterion_visitor.location_id_in:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Location\CriterionVisitor\LocationIdIn
+        tags:
+            - { name: ezpublish.search.solr.query.location.criterion_visitor }
+
+    netgen.search.solr.query.location.criterion_visitor.location_id_between:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Location\CriterionVisitor\LocationIdBetween
+        tags:
+            - { name: ezpublish.search.solr.query.location.criterion_visitor }

--- a/lib/Resources/config/search/solr/criterion_visitors.yml
+++ b/lib/Resources/config/search/solr/criterion_visitors.yml
@@ -46,12 +46,14 @@ services:
     netgen.search.solr.query.common.criterion_visitor.content_id_in:
         class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor\ContentIdIn
         tags:
-            - { name: ezpublish.search.solr.query.common.criterion_visitor }
+            - { name: ezpublish.search.solr.query.content.criterion_visitor }
+            - { name: ezpublish.search.solr.query.location.criterion_visitor }
 
     netgen.search.solr.query.common.criterion_visitor.content_id_between:
         class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor\ContentIdBetween
         tags:
-            - { name: ezpublish.search.solr.query.common.criterion_visitor }
+            - { name: ezpublish.search.solr.query.content.criterion_visitor }
+            - { name: ezpublish.search.solr.query.location.criterion_visitor }
 
     netgen.search.solr.query.content.criterion_visitor.location_id_in:
         class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Content\CriterionVisitor\LocationIdIn

--- a/lib/Resources/config/search/solr/field_mappers.yml
+++ b/lib/Resources/config/search/solr/field_mappers.yml
@@ -1,9 +1,21 @@
 services:
-    netgen.search.solr.field_mapper.content.is_field_empty:
+    netgen.search.solr.field_mapper.content_translation.is_field_empty:
         class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\FieldMapper\ContentTranslation\IsFieldEmptyFieldMapper
         arguments:
             - '@ezpublish.spi.persistence.content_type_handler'
             - '@ezpublish.search.common.field_name_generator'
             - '@ezpublish.persistence.field_type_registry'
         tags:
-            - {name: ezpublish.search.solr.field_mapper.block_translation}
+            - { name: ezpublish.search.solr.field_mapper.block_translation }
+
+    netgen.search.solr.field_mapper.content.content_and_location_id:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\FieldMapper\Content\ContentAndLocationIdFieldMapper
+        arguments:
+            - '@ezpublish.spi.persistence.location_handler'
+        tags:
+            - { name: ezpublish.search.solr.field_mapper.block }
+
+    netgen.search.solr.field_mapper.location.location_id:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\FieldMapper\Location\LocationIdFieldMapper
+        tags:
+            - { name: ezpublish.search.solr.field_mapper.location }

--- a/tests/lib/Integration/API/BaseTest.php
+++ b/tests/lib/Integration/API/BaseTest.php
@@ -16,7 +16,7 @@ abstract class BaseTest extends APIBaseTest
         $totalCount = null
     ) {
         $totalCount = $totalCount ?: count($expectedIds);
-        $this->assertEquals($totalCount, $searchResult->totalCount);
+        self::assertEquals($totalCount, $searchResult->totalCount);
 
         $foundIds = [];
 
@@ -34,7 +34,34 @@ abstract class BaseTest extends APIBaseTest
             }
         }
 
-        $this->assertEquals($expectedIds, $foundIds);
+        self::assertEquals($expectedIds, $foundIds);
+    }
+
+    protected function assertSearchResultLocationIds(
+        SearchResult $searchResult,
+        array $expectedIds,
+        $totalCount = null
+    ) {
+        $totalCount = $totalCount ?: count($expectedIds);
+        self::assertEquals($totalCount, $searchResult->totalCount);
+
+        $foundIds = [];
+
+        foreach ($searchResult->searchHits as $searchHit) {
+            $value = $searchHit->valueObject;
+
+            if ($value instanceof ContentInfo) {
+                $foundIds[] = $value->mainLocationId;
+            } elseif ($value instanceof Location) {
+                $foundIds[] = $value->id;
+            } else {
+                throw new RuntimeException(
+                    'Unknown value type: ' . get_class($value)
+                );
+            }
+        }
+
+        self::assertEquals($expectedIds, $foundIds);
     }
 
     protected function getSearchService($initialInitializeFromScratch = true)

--- a/tests/lib/Integration/API/ContentIdCriterionTest.php
+++ b/tests/lib/Integration/API/ContentIdCriterionTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Tests\Integration\API;
+
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentId as ContentIdSortClause;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\ContentId;
+
+class ContentIdCriterionTest extends BaseTest
+{
+    public function providerForTestFind()
+    {
+        return [
+            [
+                new LocationQuery([
+                    'filter' => new ContentId(Operator::EQ, 14),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [14],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new ContentId(Operator::IN, [4, 10, 14, 41, 50, 57]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [4, 10, 14, 41, 50, 57],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new ContentId(Operator::IN, [4, 10, 14, 41, 50, 57]),
+                        new ContentId(Operator::GT, 14),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [41, 50, 57],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new ContentId(Operator::IN, [4, 10, 14, 41, 50, 57]),
+                        new ContentId(Operator::GTE, 14),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [14, 41, 50, 57],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new ContentId(Operator::IN, [4, 10, 14, 41, 50, 57]),
+                        new ContentId(Operator::LT, 41),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [4, 10, 14],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new ContentId(Operator::IN, [4, 10, 14, 41, 50, 57]),
+                        new ContentId(Operator::LTE, 41),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [4, 10, 14, 41],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new ContentId(Operator::IN, [4, 10, 14, 41, 50, 57]),
+                        new ContentId(Operator::BETWEEN, [14, 50]),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [14, 41, 50],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForTestFind
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     * @param array $expectedIds
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testFindContent(Query $query, array $expectedIds)
+    {
+        $searchService = $this->getSearchService();
+
+        $searchResult = $searchService->findContentInfo($query);
+
+        $this->assertSearchResultContentIds($searchResult, $expectedIds);
+    }
+
+    /**
+     * @dataProvider providerForTestFind
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\LocationQuery $query
+     * @param array $expectedIds
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testFindLocations(LocationQuery $query, array $expectedIds)
+    {
+        $searchService = $this->getSearchService();
+
+        $searchResult = $searchService->findLocations($query);
+
+        $this->assertSearchResultContentIds($searchResult, $expectedIds);
+    }
+}

--- a/tests/lib/Integration/API/LocationIdCriterionTest.php
+++ b/tests/lib/Integration/API/LocationIdCriterionTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Tests\Integration\API;
+
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentId as ContentIdSortClause;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\LocationId;
+
+class LocationIdCriterionTest extends BaseTest
+{
+    public function providerForTestFind()
+    {
+        return [
+            [
+                new LocationQuery([
+                    'filter' => new LocationId(Operator::EQ, 12),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [12],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LocationId(Operator::IN, [12, 13, 14, 15, 43, 44]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [12, 13, 14, 15, 43, 44],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new LocationId(Operator::IN, [12, 13, 14, 15, 43, 44]),
+                        new LocationId(Operator::GT, 14),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [15, 43, 44],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new LocationId(Operator::IN, [12, 13, 14, 15, 43, 44]),
+                        new LocationId(Operator::GTE, 14),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [14, 15, 43, 44],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new LocationId(Operator::IN, [12, 13, 14, 15, 43, 44]),
+                        new LocationId(Operator::LT, 15),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [12, 13, 14],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new LocationId(Operator::IN, [12, 13, 14, 15, 43, 44]),
+                        new LocationId(Operator::LTE, 15),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [12, 13, 14, 15],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new LocationId(Operator::IN, [12, 13, 14, 15, 43, 44]),
+                        new LocationId(Operator::BETWEEN, [13, 15]),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [13, 14, 15],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForTestFind
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     * @param array $expectedIds
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testFindContent(Query $query, array $expectedIds)
+    {
+        $searchService = $this->getSearchService();
+
+        $searchResult = $searchService->findContentInfo($query);
+
+        $this->assertSearchResultLocationIds($searchResult, $expectedIds);
+    }
+
+    /**
+     * @dataProvider providerForTestFind
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\LocationQuery $query
+     * @param array $expectedIds
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testFindLocations(LocationQuery $query, array $expectedIds)
+    {
+        $searchService = $this->getSearchService();
+
+        $searchResult = $searchService->findLocations($query);
+
+        $this->assertSearchResultLocationIds($searchResult, $expectedIds);
+    }
+}

--- a/tests/lib/Integration/API/SubdocumentFieldSortClauseTest.php
+++ b/tests/lib/Integration/API/SubdocumentFieldSortClauseTest.php
@@ -325,7 +325,7 @@ class SubdocumentFieldSortClauseTest extends BaseTest
                         new ContentIdSortClause(Query::SORT_ASC),
                     ],
                 ]),
-                [12, 4, 42, 59],
+                [4, 12, 42, 59],
             ],
             [
                 new Query([
@@ -341,7 +341,7 @@ class SubdocumentFieldSortClauseTest extends BaseTest
                         new ContentIdSortClause(Query::SORT_DESC),
                     ],
                 ]),
-                [59, 42, 4, 12],
+                [59, 42, 12, 4],
             ],
         ];
     }

--- a/tests/lib/Integration/API/SubdocumentFieldSortClauseTest.php
+++ b/tests/lib/Integration/API/SubdocumentFieldSortClauseTest.php
@@ -145,7 +145,7 @@ class SubdocumentFieldSortClauseTest extends BaseTest
                         new ContentIdSortClause(Query::SORT_ASC),
                     ],
                 ]),
-                [12, 4, 42, 59],
+                [4, 12, 42, 59],
             ],
             [
                 new Query([
@@ -160,7 +160,7 @@ class SubdocumentFieldSortClauseTest extends BaseTest
                         new ContentIdSortClause(Query::SORT_DESC),
                     ],
                 ]),
-                [59, 42, 4, 12],
+                [59, 42, 12, 4],
             ],
         ];
     }

--- a/tests/lib/Integration/API/SubdocumentQueryCriterionTest.php
+++ b/tests/lib/Integration/API/SubdocumentQueryCriterionTest.php
@@ -92,7 +92,7 @@ class SubdocumentQueryCriterionTest extends BaseTest
                     'sortClauses' => [new ContentIdSortClause()],
                 ]),
                 [],
-                [13, 4, 42, 59],
+                [4, 13, 42, 59],
             ],
             [
                 new Query([
@@ -111,7 +111,7 @@ class SubdocumentQueryCriterionTest extends BaseTest
                     'sortClauses' => [new ContentIdSortClause()],
                 ]),
                 [],
-                [13, 4, 59],
+                [4, 13, 59],
             ],
             [
                 new Query([
@@ -213,7 +213,7 @@ class SubdocumentQueryCriterionTest extends BaseTest
                     'sortClauses' => [new ContentIdSortClause()],
                 ]),
                 ['languages' => ['ger-DE']],
-                [12, 13, 4, 42],
+                [4, 12, 13, 42],
             ],
             [
                 new Query([

--- a/tests/lib/Integration/Implementation/Solr/SubdocumentMapper/TestContentSubdocumentMapper.php
+++ b/tests/lib/Integration/Implementation/Solr/SubdocumentMapper/TestContentSubdocumentMapper.php
@@ -9,7 +9,7 @@ use eZ\Publish\SPI\Search\Document;
 use Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentSubdocumentMapper;
 
 /**
- * Note: here we  are only simulating indexing children data.
+ * Note: here we are only simulating indexing children data.
  */
 class TestContentSubdocumentMapper extends ContentSubdocumentMapper
 {

--- a/tests/lib/Integration/Implementation/Solr/SubdocumentMapper/TestSortContentSubdocumentMapper.php
+++ b/tests/lib/Integration/Implementation/Solr/SubdocumentMapper/TestSortContentSubdocumentMapper.php
@@ -9,7 +9,7 @@ use eZ\Publish\SPI\Search\Document;
 use Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentSubdocumentMapper;
 
 /**
- * Note: here we  are only simulating indexing children data.
+ * Note: here we are only simulating indexing children data.
  */
 class TestSortContentSubdocumentMapper extends ContentSubdocumentMapper
 {

--- a/tests/lib/Kernel/SearchServiceTest.php
+++ b/tests/lib/Kernel/SearchServiceTest.php
@@ -9,18 +9,14 @@ use Netgen\EzPlatformSearchExtra\API\Values\Content\Search\SearchResult;
 
 class SearchServiceTest extends KernelSearchServiceTest
 {
-    /**
-     * Assert that query result matches the given fixture.
-     *
-     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
-     * @param string $fixture
-     * @param null|callable $closure
-     * @param bool $info
-     * @param bool $ignoreScore
-     * @param bool $id
-     */
-    protected function assertQueryFixture(Query $query, $fixture, $closure = null, $ignoreScore = true, $info = false, $id = true)
-    {
+    protected function assertQueryFixture(
+        Query $query,
+        string $fixtureFilePath,
+        ?callable $closure = null,
+        bool $ignoreScore = true,
+        bool $info = false,
+        bool $id = true
+    ): void {
         $newClosure = function (&$data) use ($closure) {
             if ($data instanceof SearchResult) {
                 $data = $this->mapToKernelSearchResult($data);
@@ -31,10 +27,10 @@ class SearchServiceTest extends KernelSearchServiceTest
             }
         };
 
-        return parent::assertQueryFixture($query, $fixture, $newClosure, $ignoreScore, $info, $id);
+        parent::assertQueryFixture($query, $fixtureFilePath, $newClosure, $ignoreScore, $info, $id);
     }
 
-    private function mapToKernelSearchResult(SearchResult $data)
+    private function mapToKernelSearchResult(SearchResult $data): KernelSearchResult
     {
         return new KernelSearchResult([
             'facets' => $data->facets,


### PR DESCRIPTION
Some missing bits for the upcoming preceding/following sibling feature in https://github.com/netgen/ezplatform-site-api.