### PR TITLE
NGSTACK-361: add ContentId and LocationId criteria with extended operator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Only a list of features is provided here, see
 [documentation](https://netgen-ezplatform-search-extra.readthedocs.io)
 for more details.
 
+- `ContentId` and `LocationId` criteria with support for range operators  (`solr`, `legacy`)
+
+  Supported operators are: `EQ`, `IN`, `GT`, `GTE`, `LT`, `LTE`, `BETWEEN`.
+
 - [`Visible`](https://github.com/netgen/ezplatform-search-extra/blob/master/lib/API/Values/Content/Query/Criterion/Visible.php) criterion (`solr`, `legacy`),
   usable in both Content and Location search. The criterion works on compound visiblity of Content and Location objects:
   the Content is visible if it's marked as visible; the Location is visible if it's marked as visible, is not hidden by

--- a/lib/API/Values/Content/Query/Criterion/ContentId.php
+++ b/lib/API/Values/Content/Query/Criterion/ContentId.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
+
+/**
+ * A criterion that matches Content based on its ID.
+ */
+class ContentId extends Criterion
+{
+    /**
+     * @param string $operator One of the Operator constants
+     * @param int|int[] $value One or more Content IDs that must be matched
+     */
+    public function __construct(string $operator, $value)
+    {
+        parent::__construct(null, $operator, $value);
+    }
+
+    public function getSpecifications(): array
+    {
+        return [
+            new Specifications(Operator::EQ, Specifications::FORMAT_SINGLE, Specifications::TYPE_INTEGER),
+            new Specifications(Operator::IN, Specifications::FORMAT_ARRAY, Specifications::TYPE_INTEGER),
+            new Specifications(Operator::GT, Specifications::FORMAT_SINGLE, Specifications::TYPE_INTEGER),
+            new Specifications(Operator::GTE, Specifications::FORMAT_SINGLE, Specifications::TYPE_INTEGER),
+            new Specifications(Operator::LT, Specifications::FORMAT_SINGLE, Specifications::TYPE_INTEGER),
+            new Specifications(Operator::LTE, Specifications::FORMAT_SINGLE, Specifications::TYPE_INTEGER),
+            new Specifications(Operator::BETWEEN, Specifications::FORMAT_ARRAY, Specifications::TYPE_INTEGER, 2),
+        ];
+    }
+}

--- a/lib/API/Values/Content/Query/Criterion/LocationId.php
+++ b/lib/API/Values/Content/Query/Criterion/LocationId.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
+
+/**
+ * A criterion that matches Location based on its ID.
+ */
+class LocationId extends Criterion
+{
+    /**
+     * @param string $operator One of the Operator constants
+     * @param int|int[] $value One or more Location IDs that must be matched
+     */
+    public function __construct(string $operator, $value)
+    {
+        parent::__construct(null, $operator, $value);
+    }
+
+    public function getSpecifications(): array
+    {
+        return [
+            new Specifications(Operator::EQ, Specifications::FORMAT_SINGLE, Specifications::TYPE_INTEGER),
+            new Specifications(Operator::IN, Specifications::FORMAT_ARRAY, Specifications::TYPE_INTEGER),
+            new Specifications(Operator::GT, Specifications::FORMAT_SINGLE, Specifications::TYPE_INTEGER),
+            new Specifications(Operator::GTE, Specifications::FORMAT_SINGLE, Specifications::TYPE_INTEGER),
+            new Specifications(Operator::LT, Specifications::FORMAT_SINGLE, Specifications::TYPE_INTEGER),
+            new Specifications(Operator::LTE, Specifications::FORMAT_SINGLE, Specifications::TYPE_INTEGER),
+            new Specifications(Operator::BETWEEN, Specifications::FORMAT_ARRAY, Specifications::TYPE_INTEGER, 2),
+        ];
+    }
+}

--- a/lib/Core/Search/Legacy/Query/Common/CriterionHandler/ContentId.php
+++ b/lib/Core/Search/Legacy/Query/Common/CriterionHandler/ContentId.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Legacy\Query\Common\CriterionHandler;
+
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Query\QueryBuilder;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\ContentId as ContentIdCriterion;
+use RuntimeException;
+
+/**
+ * @see \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\ContentId
+ */
+final class ContentId extends CriterionHandler
+{
+    public function accept(Criterion $criterion): bool
+    {
+        return $criterion instanceof ContentIdCriterion;
+    }
+
+    public function handle(
+        CriteriaConverter $converter,
+        QueryBuilder $queryBuilder,
+        Criterion $criterion,
+        array $languageSettings
+    ): string {
+        $column = 'c.id';
+
+        switch ($criterion->operator) {
+            case Operator::EQ:
+            case Operator::IN:
+                return $queryBuilder->expr()->in($column, $criterion->value);
+
+            case Operator::GT:
+            case Operator::GTE:
+            case Operator::LT:
+            case Operator::LTE:
+                $operatorFunction = $this->comparatorMap[$criterion->operator];
+
+                return $queryBuilder->expr()->$operatorFunction(
+                    $column,
+                    $queryBuilder->createNamedParameter(reset($criterion->value), ParameterType::INTEGER)
+                );
+
+            case Operator::BETWEEN:
+                return $this->dbPlatform->getBetweenExpression(
+                    $column,
+                    $queryBuilder->createNamedParameter($criterion->value[0], ParameterType::INTEGER),
+                    $queryBuilder->createNamedParameter($criterion->value[1], ParameterType::INTEGER)
+                );
+
+            default:
+                throw new RuntimeException(
+                    "Unknown operator '{$criterion->operator}' for ContentId criterion handler."
+                );
+        }
+    }
+}

--- a/lib/Core/Search/Legacy/Query/Content/CriterionHandler/LocationId.php
+++ b/lib/Core/Search/Legacy/Query/Content/CriterionHandler/LocationId.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Legacy\Query\Content\CriterionHandler;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Query\QueryBuilder;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\LocationId as LocationIdCriterion;
+use RuntimeException;
+
+/**
+ * @see \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\LocationId
+ */
+final class LocationId extends CriterionHandler
+{
+    public function accept(Criterion $criterion)
+    {
+        return $criterion instanceof LocationIdCriterion;
+    }
+
+    public function handle(
+        CriteriaConverter $converter,
+        QueryBuilder $queryBuilder,
+        Criterion $criterion,
+        array $languageSettings
+    ) {
+        $column = 'node_id';
+        $subSelect = $this->connection->createQueryBuilder();
+
+        switch ($criterion->operator) {
+            case Operator::EQ:
+            case Operator::IN:
+                $expression = $queryBuilder->expr()->in($column, $criterion->value);
+
+                break;
+
+            case Operator::GT:
+            case Operator::GTE:
+            case Operator::LT:
+            case Operator::LTE:
+                $operatorFunction = $this->comparatorMap[$criterion->operator];
+                $expression = $queryBuilder->expr()->$operatorFunction(
+                    $column,
+                    $queryBuilder->createNamedParameter(reset($criterion->value), ParameterType::INTEGER)
+                );
+
+                break;
+
+            case Operator::BETWEEN:
+                $expression = $this->dbPlatform->getBetweenExpression(
+                    $column,
+                    $queryBuilder->createNamedParameter($criterion->value[0], ParameterType::INTEGER),
+                    $queryBuilder->createNamedParameter($criterion->value[1], ParameterType::INTEGER)
+                );
+
+                break;
+
+            default:
+                throw new RuntimeException(
+                    "Unknown operator '{$criterion->operator}' for LocationId criterion handler."
+                );
+        }
+
+        $subSelect->select('contentobject_id')->from('ezcontentobject_tree')->where($expression);
+
+        return $queryBuilder->expr()->in('c.id', $subSelect->getSQL());
+    }
+}

--- a/lib/Core/Search/Legacy/Query/Location/CriterionHandler/LocationId.php
+++ b/lib/Core/Search/Legacy/Query/Location/CriterionHandler/LocationId.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Legacy\Query\Location\CriterionHandler;
+
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Query\QueryBuilder;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\LocationId as LocationIdCriterion;
+use RuntimeException;
+
+/**
+ * @see \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\LocationId
+ */
+final class LocationId extends CriterionHandler
+{
+    public function accept(Criterion $criterion): bool
+    {
+        return $criterion instanceof LocationIdCriterion;
+    }
+
+    public function handle(
+        CriteriaConverter $converter,
+        QueryBuilder $queryBuilder,
+        Criterion $criterion,
+        array $languageSettings
+    ) {
+        $column = 't.node_id';
+
+        switch ($criterion->operator) {
+            case Operator::EQ:
+            case Operator::IN:
+                return $queryBuilder->expr()->in($column, $criterion->value);
+
+            case Operator::GT:
+            case Operator::GTE:
+            case Operator::LT:
+            case Operator::LTE:
+                $operatorFunction = $this->comparatorMap[$criterion->operator];
+
+                return $queryBuilder->expr()->$operatorFunction(
+                    $column,
+                    $queryBuilder->createNamedParameter(reset($criterion->value), ParameterType::INTEGER)
+                );
+
+            case Operator::BETWEEN:
+                return $this->dbPlatform->getBetweenExpression(
+                    $column,
+                    $queryBuilder->createNamedParameter($criterion->value[0], ParameterType::INTEGER),
+                    $queryBuilder->createNamedParameter($criterion->value[1], ParameterType::INTEGER)
+                );
+
+            default:
+                throw new RuntimeException(
+                    "Unknown operator '{$criterion->operator}' for LocationId criterion handler."
+                );
+        }
+    }
+}

--- a/lib/Core/Search/Solr/FieldMapper/Content/ContentAndLocationIdFieldMapper.php
+++ b/lib/Core/Search/Solr/FieldMapper/Content/ContentAndLocationIdFieldMapper.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\FieldMapper\Content;
+
+use eZ\Publish\SPI\Persistence\Content as SPIContent;
+use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandler;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType\IntegerField;
+use eZ\Publish\SPI\Search\FieldType\MultipleIntegerField;
+use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper;
+
+class ContentAndLocationIdFieldMapper extends ContentFieldMapper
+{
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Location\Handler
+     */
+    protected $locationHandler;
+
+    /**
+     * @param \eZ\Publish\SPI\Persistence\Content\Location\Handler $locationHandler
+     */
+    public function __construct(LocationHandler $locationHandler)
+    {
+        $this->locationHandler = $locationHandler;
+    }
+
+    public function accept(SPIContent $content): bool
+    {
+        return true;
+    }
+
+    public function mapFields(SPIContent $content): array
+    {
+        $locations = $this->locationHandler->loadLocationsByContent($content->versionInfo->contentInfo->id);
+        $locationIds = [];
+
+        foreach ($locations as $location) {
+            $locationIds[] = $location->id;
+        }
+
+        return [
+            new Field(
+                'ng_content_id',
+                $content->versionInfo->contentInfo->id,
+                new IntegerField()
+            ),
+            new Field(
+                'ng_location_id',
+                $locationIds,
+                new MultipleIntegerField()
+            ),
+        ];
+    }
+}

--- a/lib/Core/Search/Solr/FieldMapper/Location/LocationIdFieldMapper.php
+++ b/lib/Core/Search/Solr/FieldMapper/Location/LocationIdFieldMapper.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\FieldMapper\Location;
+
+use eZ\Publish\SPI\Persistence\Content\Location as SPILocation;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType\IntegerField;
+use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper;
+
+class LocationIdFieldMapper extends LocationFieldMapper
+{
+    public function accept(SPILocation $location): bool
+    {
+        return true;
+    }
+
+    public function mapFields(SPILocation $location): array
+    {
+        return [
+            new Field(
+                'ng_location_id',
+                $location->id,
+                new IntegerField()
+            ),
+        ];
+    }
+}

--- a/lib/Core/Search/Solr/Query/Common/CriterionVisitor/ContentIdBetween.php
+++ b/lib/Core/Search/Solr/Query/Common/CriterionVisitor/ContentIdBetween.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\ContentId as ContentIdCriterion;
+
+/**
+ * Visits the ContentId criterion.
+ *
+ * @see \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\ContentId
+ */
+final class ContentIdBetween extends CriterionVisitor
+{
+    public function canVisit(Criterion $criterion): bool
+    {
+        return
+            $criterion instanceof ContentIdCriterion
+            && (
+                $criterion->operator === Operator::LT
+                || $criterion->operator === Operator::LTE
+                || $criterion->operator === Operator::GT
+                || $criterion->operator === Operator::GTE
+                || $criterion->operator === Operator::BETWEEN
+            );
+    }
+
+    public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null): string
+    {
+        $start = $criterion->value[0];
+        $end = $criterion->value[1] ?? null;
+
+        if ($criterion->operator === Operator::LT || $criterion->operator === Operator::LTE) {
+            $end = $start;
+            $start = null;
+        }
+
+        return 'ng_content_id_i:' . $this->getRange($criterion->operator, $start, $end);
+    }
+}

--- a/lib/Core/Search/Solr/Query/Common/CriterionVisitor/ContentIdIn.php
+++ b/lib/Core/Search/Solr/Query/Common/CriterionVisitor/ContentIdIn.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\ContentId as ContentIdCriterion;
+
+/**
+ * Visits the ContentId criterion.
+ *
+ * @see \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\ContentId
+ */
+final class ContentIdIn extends CriterionVisitor
+{
+    public function canVisit(Criterion $criterion): bool
+    {
+        return
+            $criterion instanceof ContentIdCriterion
+            && (
+                $criterion->operator === Operator::IN
+                || $criterion->operator === Operator::EQ
+            );
+    }
+
+    public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null): string
+    {
+        $values = array();
+
+        foreach ($criterion->value as $value) {
+            $values[] = 'ng_content_id_i:"' . $value . '"';
+        }
+
+        return '(' . implode(' OR ', $values) . ')';
+    }
+}

--- a/lib/Core/Search/Solr/Query/Content/CriterionVisitor/LocationIdBetween.php
+++ b/lib/Core/Search/Solr/Query/Content/CriterionVisitor/LocationIdBetween.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Content\CriterionVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\LocationId as LocationIdCriterion;
+
+/**
+ * Visits the LocationId criterion.
+ *
+ * @see \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\LocationId
+ */
+class LocationIdBetween extends CriterionVisitor
+{
+    public function canVisit(Criterion $criterion): bool
+    {
+        return
+            $criterion instanceof LocationIdCriterion
+            && (
+                $criterion->operator === Operator::LT
+                || $criterion->operator === Operator::LTE
+                || $criterion->operator === Operator::GT
+                || $criterion->operator === Operator::GTE
+                || $criterion->operator === Operator::BETWEEN
+            );
+    }
+
+    public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null): string
+    {
+        $start = $criterion->value[0];
+        $end = $criterion->value[1] ?? null;
+
+        if ($criterion->operator === Operator::LT || $criterion->operator === Operator::LTE) {
+            $end = $start;
+            $start = null;
+        }
+
+        return 'ng_location_id_mi:' . $this->getRange($criterion->operator, $start, $end);
+    }
+}

--- a/lib/Core/Search/Solr/Query/Content/CriterionVisitor/LocationIdIn.php
+++ b/lib/Core/Search/Solr/Query/Content/CriterionVisitor/LocationIdIn.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Content\CriterionVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\LocationId as LocationIdCriterion;
+
+/**
+ * Visits the LocationId criterion.
+ *
+ * @see \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\LocationId
+ */
+class LocationIdIn extends CriterionVisitor
+{
+    public function canVisit(Criterion $criterion): bool
+    {
+        return
+            $criterion instanceof LocationIdCriterion
+            && (
+                $criterion->operator === Operator::IN
+                || $criterion->operator === Operator::EQ
+            );
+    }
+
+    public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null): string
+    {
+        $values = array();
+
+        foreach ($criterion->value as $value) {
+            $values[] = 'ng_location_id_mi:"' . $value . '"';
+        }
+
+        return '(' . implode(' OR ', $values) . ')';
+    }
+}

--- a/lib/Core/Search/Solr/Query/Location/CriterionVisitor/LocationIdBetween.php
+++ b/lib/Core/Search/Solr/Query/Location/CriterionVisitor/LocationIdBetween.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Location\CriterionVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\LocationId as LocationIdCriterion;
+
+/**
+ * Visits the LocationId criterion.
+ *
+ * @see \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\LocationId
+ */
+class LocationIdBetween extends CriterionVisitor
+{
+    public function canVisit(Criterion $criterion): bool
+    {
+        return
+            $criterion instanceof LocationIdCriterion
+            && (
+                $criterion->operator === Operator::LT
+                || $criterion->operator === Operator::LTE
+                || $criterion->operator === Operator::GT
+                || $criterion->operator === Operator::GTE
+                || $criterion->operator === Operator::BETWEEN
+            );
+    }
+
+    public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null): string
+    {
+        $start = $criterion->value[0];
+        $end = $criterion->value[1] ?? null;
+
+        if ($criterion->operator === Operator::LT || $criterion->operator === Operator::LTE) {
+            $end = $start;
+            $start = null;
+        }
+
+        return 'ng_location_id_i:' . $this->getRange($criterion->operator, $start, $end);
+    }
+}

--- a/lib/Core/Search/Solr/Query/Location/CriterionVisitor/LocationIdIn.php
+++ b/lib/Core/Search/Solr/Query/Location/CriterionVisitor/LocationIdIn.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Location\CriterionVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\LocationId as LocationIdCriterion;
+
+/**
+ * Visits the LocationId criterion.
+ *
+ * @see \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\LocationId
+ */
+class LocationIdIn extends CriterionVisitor
+{
+    public function canVisit(Criterion $criterion): bool
+    {
+        return
+            $criterion instanceof LocationIdCriterion
+            && (
+                $criterion->operator === Operator::IN
+                || $criterion->operator === Operator::EQ
+            );
+    }
+
+    public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null): string
+    {
+        $values = array();
+
+        foreach ($criterion->value as $value) {
+            $values[] = 'ng_location_id_i:"' . $value . '"';
+        }
+
+        return '(' . implode(' OR ', $values) . ')';
+    }
+}

--- a/lib/Resources/config/search/legacy.yml
+++ b/lib/Resources/config/search/legacy.yml
@@ -89,3 +89,25 @@ services:
             - '@ezpublish.persistence.connection'
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+
+    netgen.search.legacy.query.common.criterion_visitor.content_id:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Legacy\Query\Common\CriterionHandler\ContentId
+        arguments:
+            - '@ezpublish.persistence.connection'
+        tags:
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+
+    netgen.search.legacy.query.content.criterion_visitor.location_id:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Legacy\Query\Content\CriterionHandler\LocationId
+        arguments:
+            - '@ezpublish.persistence.connection'
+        tags:
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
+
+    netgen.search.legacy.query.location.criterion_visitor.location_id:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Legacy\Query\Location\CriterionHandler\LocationId
+        arguments:
+            - '@ezpublish.persistence.connection'
+        tags:
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}

--- a/lib/Resources/config/search/solr/criterion_visitors.yml
+++ b/lib/Resources/config/search/solr/criterion_visitors.yml
@@ -52,3 +52,35 @@ services:
         class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Location\CriterionVisitor\Visible
         tags:
             - { name: ezpublish.search.solr.query.location.criterion_visitor }
+
+    netgen.search.solr.query.common.criterion_visitor.content_id_in:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor\ContentIdIn
+        tags:
+            - { name: ezpublish.search.solr.query.content.criterion_visitor }
+            - { name: ezpublish.search.solr.query.location.criterion_visitor }
+
+    netgen.search.solr.query.common.criterion_visitor.content_id_between:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor\ContentIdBetween
+        tags:
+            - { name: ezpublish.search.solr.query.content.criterion_visitor }
+            - { name: ezpublish.search.solr.query.location.criterion_visitor }
+
+    netgen.search.solr.query.content.criterion_visitor.location_id_in:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Content\CriterionVisitor\LocationIdIn
+        tags:
+            - { name: ezpublish.search.solr.query.content.criterion_visitor }
+
+    netgen.search.solr.query.content.criterion_visitor.location_id_between:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Content\CriterionVisitor\LocationIdBetween
+        tags:
+            - { name: ezpublish.search.solr.query.content.criterion_visitor }
+
+    netgen.search.solr.query.location.criterion_visitor.location_id_in:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Location\CriterionVisitor\LocationIdIn
+        tags:
+            - { name: ezpublish.search.solr.query.location.criterion_visitor }
+
+    netgen.search.solr.query.location.criterion_visitor.location_id_between:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Location\CriterionVisitor\LocationIdBetween
+        tags:
+            - { name: ezpublish.search.solr.query.location.criterion_visitor }

--- a/lib/Resources/config/search/solr/field_mappers.yml
+++ b/lib/Resources/config/search/solr/field_mappers.yml
@@ -1,5 +1,5 @@
 services:
-    netgen.search.solr.field_mapper.content.is_field_empty:
+    netgen.search.solr.field_mapper.content_translation.is_field_empty:
         class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\FieldMapper\ContentTranslation\IsFieldEmptyFieldMapper
         arguments:
             - '@ezpublish.spi.persistence.content_type_handler'
@@ -17,5 +17,17 @@ services:
         class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\FieldMapper\Location\LocationVisibilityFieldMapper
         arguments:
             - '@ezpublish.spi.persistence.content_handler'
+        tags:
+            - { name: ezpublish.search.solr.field_mapper.location }
+
+    netgen.search.solr.field_mapper.content.content_and_location_id:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\FieldMapper\Content\ContentAndLocationIdFieldMapper
+        arguments:
+            - '@ezpublish.spi.persistence.location_handler'
+        tags:
+            - { name: ezpublish.search.solr.field_mapper.block }
+
+    netgen.search.solr.field_mapper.location.location_id:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\FieldMapper\Location\LocationIdFieldMapper
         tags:
             - { name: ezpublish.search.solr.field_mapper.location }

--- a/tests/lib/Integration/API/BaseTest.php
+++ b/tests/lib/Integration/API/BaseTest.php
@@ -16,7 +16,7 @@ abstract class BaseTest extends APIBaseTest
         $totalCount = null
     ) {
         $totalCount = $totalCount ?: count($expectedIds);
-        $this->assertEquals($totalCount, $searchResult->totalCount);
+        self::assertEquals($totalCount, $searchResult->totalCount);
 
         $foundIds = [];
 
@@ -34,7 +34,34 @@ abstract class BaseTest extends APIBaseTest
             }
         }
 
-        $this->assertEquals($expectedIds, $foundIds);
+        self::assertEquals($expectedIds, $foundIds);
+    }
+
+    protected function assertSearchResultLocationIds(
+        SearchResult $searchResult,
+        array $expectedIds,
+        $totalCount = null
+    ) {
+        $totalCount = $totalCount ?: count($expectedIds);
+        self::assertEquals($totalCount, $searchResult->totalCount);
+
+        $foundIds = [];
+
+        foreach ($searchResult->searchHits as $searchHit) {
+            $value = $searchHit->valueObject;
+
+            if ($value instanceof ContentInfo) {
+                $foundIds[] = $value->mainLocationId;
+            } elseif ($value instanceof Location) {
+                $foundIds[] = $value->id;
+            } else {
+                throw new RuntimeException(
+                    'Unknown value type: ' . get_class($value)
+                );
+            }
+        }
+
+        self::assertEquals($expectedIds, $foundIds);
     }
 
     protected function getSearchService($initialInitializeFromScratch = true)

--- a/tests/lib/Integration/API/ContentIdCriterionTest.php
+++ b/tests/lib/Integration/API/ContentIdCriterionTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Tests\Integration\API;
+
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentId as ContentIdSortClause;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\ContentId;
+
+class ContentIdCriterionTest extends BaseTest
+{
+    public function providerForTestFind(): array
+    {
+        return [
+            [
+                new LocationQuery([
+                    'filter' => new ContentId(Operator::EQ, 14),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [14],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new ContentId(Operator::IN, [4, 10, 14, 41, 50, 57]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [4, 10, 14, 41, 50, 57],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new ContentId(Operator::IN, [4, 10, 14, 41, 50, 57]),
+                        new ContentId(Operator::GT, 14),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [41, 50, 57],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new ContentId(Operator::IN, [4, 10, 14, 41, 50, 57]),
+                        new ContentId(Operator::GTE, 14),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [14, 41, 50, 57],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new ContentId(Operator::IN, [4, 10, 14, 41, 50, 57]),
+                        new ContentId(Operator::LT, 41),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [4, 10, 14],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new ContentId(Operator::IN, [4, 10, 14, 41, 50, 57]),
+                        new ContentId(Operator::LTE, 41),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [4, 10, 14, 41],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new ContentId(Operator::IN, [4, 10, 14, 41, 50, 57]),
+                        new ContentId(Operator::BETWEEN, [14, 50]),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [14, 41, 50],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForTestFind
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     * @param array $expectedIds
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testFindContent(Query $query, array $expectedIds): void
+    {
+        $searchService = $this->getSearchService();
+
+        $searchResult = $searchService->findContentInfo($query);
+
+        $this->assertSearchResultContentIds($searchResult, $expectedIds);
+    }
+
+    /**
+     * @dataProvider providerForTestFind
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\LocationQuery $query
+     * @param array $expectedIds
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testFindLocations(LocationQuery $query, array $expectedIds): void
+    {
+        $searchService = $this->getSearchService();
+
+        $searchResult = $searchService->findLocations($query);
+
+        $this->assertSearchResultContentIds($searchResult, $expectedIds);
+    }
+}

--- a/tests/lib/Integration/API/LocationIdCriterionTest.php
+++ b/tests/lib/Integration/API/LocationIdCriterionTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Tests\Integration\API;
+
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentId as ContentIdSortClause;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\LocationId;
+
+class LocationIdCriterionTest extends BaseTest
+{
+    public function providerForTestFind(): array
+    {
+        return [
+            [
+                new LocationQuery([
+                    'filter' => new LocationId(Operator::EQ, 12),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [12],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LocationId(Operator::IN, [12, 13, 14, 15, 43, 44]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [12, 13, 14, 15, 43, 44],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new LocationId(Operator::IN, [12, 13, 14, 15, 43, 44]),
+                        new LocationId(Operator::GT, 14),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [15, 43, 44],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new LocationId(Operator::IN, [12, 13, 14, 15, 43, 44]),
+                        new LocationId(Operator::GTE, 14),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [14, 15, 43, 44],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new LocationId(Operator::IN, [12, 13, 14, 15, 43, 44]),
+                        new LocationId(Operator::LT, 15),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [12, 13, 14],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new LocationId(Operator::IN, [12, 13, 14, 15, 43, 44]),
+                        new LocationId(Operator::LTE, 15),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [12, 13, 14, 15],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new LocationId(Operator::IN, [12, 13, 14, 15, 43, 44]),
+                        new LocationId(Operator::BETWEEN, [13, 15]),
+                    ]),
+                    'sortClauses' => [new ContentIdSortClause()],
+                ]),
+                [13, 14, 15],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForTestFind
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     * @param array $expectedIds
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testFindContent(Query $query, array $expectedIds): void
+    {
+        $searchService = $this->getSearchService();
+
+        $searchResult = $searchService->findContentInfo($query);
+
+        $this->assertSearchResultLocationIds($searchResult, $expectedIds);
+    }
+
+    /**
+     * @dataProvider providerForTestFind
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\LocationQuery $query
+     * @param array $expectedIds
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testFindLocations(LocationQuery $query, array $expectedIds): void
+    {
+        $searchService = $this->getSearchService();
+
+        $searchResult = $searchService->findLocations($query);
+
+        $this->assertSearchResultLocationIds($searchResult, $expectedIds);
+    }
+}

--- a/tests/lib/Integration/Implementation/Solr/SubdocumentMapper/TestContentSubdocumentMapper.php
+++ b/tests/lib/Integration/Implementation/Solr/SubdocumentMapper/TestContentSubdocumentMapper.php
@@ -9,7 +9,7 @@ use eZ\Publish\SPI\Search\Document;
 use Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentSubdocumentMapper;
 
 /**
- * Note: here we  are only simulating indexing children data.
+ * Note: here we are only simulating indexing children data.
  */
 class TestContentSubdocumentMapper extends ContentSubdocumentMapper
 {

--- a/tests/lib/Integration/Implementation/Solr/SubdocumentMapper/TestSortContentSubdocumentMapper.php
+++ b/tests/lib/Integration/Implementation/Solr/SubdocumentMapper/TestSortContentSubdocumentMapper.php
@@ -9,7 +9,7 @@ use eZ\Publish\SPI\Search\Document;
 use Netgen\EzPlatformSearchExtra\Core\Search\Solr\SubdocumentMapper\ContentSubdocumentMapper;
 
 /**
- * Note: here we  are only simulating indexing children data.
+ * Note: here we are only simulating indexing children data.
  */
 class TestSortContentSubdocumentMapper extends ContentSubdocumentMapper
 {

--- a/tests/lib/Kernel/SearchServiceTest.php
+++ b/tests/lib/Kernel/SearchServiceTest.php
@@ -9,16 +9,13 @@ use Netgen\EzPlatformSearchExtra\API\Values\Content\Search\SearchResult;
 
 class SearchServiceTest extends KernelSearchServiceTest
 {
-    /**
-     * @inheritDoc
-     */
     protected function assertQueryFixture(
         Query $query,
-        $fixture,
+        string $fixtureFilePath,
         ?callable $closure = null,
-        $ignoreScore = true,
-        $info = false,
-        $id = true
+        bool $ignoreScore = true,
+        bool $info = false,
+        bool $id = true
     ): void {
         $newClosure = function (&$data) use ($closure) {
             if ($data instanceof SearchResult) {
@@ -30,10 +27,10 @@ class SearchServiceTest extends KernelSearchServiceTest
             }
         };
 
-        parent::assertQueryFixture($query, $fixture, $newClosure, $ignoreScore, $info, $id);
+        parent::assertQueryFixture($query, $fixtureFilePath, $newClosure, $ignoreScore, $info, $id);
     }
 
-    private function mapToKernelSearchResult(SearchResult $data)
+    private function mapToKernelSearchResult(SearchResult $data): KernelSearchResult
     {
         return new KernelSearchResult([
             'facets' => $data->facets,


### PR DESCRIPTION
Counterpart of https://github.com/netgen/ezplatform-search-extra/pull/42 for 2.x line.

Some missing bits for the upcoming preceding/following sibling feature in https://github.com/netgen/ezplatform-site-api:

This implements `ContentId` and `LocationId` criteria with support for range operators. Full operator list for both: `EQ`, `IN`, `GT`, `GTE`, `LT`, `LTE`, `BETWEEN`.