### PR TITLE
NGSTACK-249: implement ContentName sort clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Only a list of features is provided here, see
 [documentation](https://netgen-ezplatform-search-extra.readthedocs.io)
 for more details.
 
+- [`ContentName`](https://github.com/netgen/ezplatform-search-extra/blob/master/lib/API/Values/Content/Query/SortClause/ContentName.php) sort that works on matched translation's Content name  (`solr`, `legacy`)
+
 - [`ContentId`](https://github.com/netgen/ezplatform-search-extra/blob/master/lib/API/Values/Content/Query/Criterion/ContentId.php) and [`LocationId`](https://github.com/netgen/ezplatform-search-extra/blob/master/lib/API/Values/Content/Query/Criterion/LocationId.php) criteria with support for range operators  (`solr`, `legacy`)
 
   Supported operators are: `EQ`, `IN`, `GT`, `GTE`, `LT`, `LTE`, `BETWEEN`.

--- a/lib/API/Values/Content/Query/SortClause/ContentName.php
+++ b/lib/API/Values/Content/Query/SortClause/ContentName.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\API\Values\Content\Query\SortClause;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+
+/**
+ * Sets sort direction on matched translation's Content name.
+ */
+final class ContentName extends SortClause
+{
+    public function __construct(string $sortDirection = Query::SORT_ASC)
+    {
+        parent::__construct('translated_content_name', $sortDirection);
+    }
+}

--- a/lib/Core/Search/Legacy/Query/Common/SortClauseHandler/ContentName.php
+++ b/lib/Core/Search/Legacy/Query/Common/SortClauseHandler/ContentName.php
@@ -7,11 +7,11 @@ namespace Netgen\EzPlatformSearchExtra\Core\Search\Legacy\Query\Common\SortClaus
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\QueryBuilder;
-use eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentName as ContentNameSortClause;
 use eZ\Publish\Core\Persistence\Legacy\Content\Gateway;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 use eZ\Publish\SPI\Persistence\Content\Language\Handler as LanguageHandler;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\SortClause\ContentName as ContentNameSortClause;
 
 class ContentName extends SortClauseHandler
 {

--- a/lib/Core/Search/Legacy/Query/Common/SortClauseHandler/ContentName.php
+++ b/lib/Core/Search/Legacy/Query/Common/SortClauseHandler/ContentName.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Legacy\Query\Common\SortClauseHandler;
+
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\SortClause\ContentName as ContentNameSortClause;
+use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
+use eZ\Publish\Core\Persistence\Database\SelectQuery;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+use eZ\Publish\SPI\Persistence\Content\Language\Handler as LanguageHandler;
+use PDO;
+
+class ContentName extends SortClauseHandler
+{
+    protected $languageHandler;
+
+    public function __construct(DatabaseHandler $dbHandler, LanguageHandler $languageHandler)
+    {
+        parent::__construct($dbHandler);
+
+        $this->languageHandler = $languageHandler;
+    }
+
+    public function accept(SortClause $sortClause): bool
+    {
+        return $sortClause instanceof ContentNameSortClause;
+    }
+
+    public function applySelect(SelectQuery $query, SortClause $sortClause, $number): array
+    {
+        $tableAlias = $this->getSortTableName($number);
+        //$tableAlias = $this->dbHandler->quoteIdentifier($tableAlias);
+        $columnAlias = $this->getSortColumnName($number);
+
+        $query->select(
+            $query->alias(
+                $this->dbHandler->quoteColumn('name', $tableAlias),
+                $columnAlias
+            )
+        );
+
+        return [$columnAlias];
+    }
+
+    /**
+     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause $sortClause
+     * @param int $number
+     * @param array $languageSettings
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function applyJoin(
+        SelectQuery $query,
+        SortClause $sortClause,
+        $number,
+        array $languageSettings
+    ): void {
+        $tableAlias = $this->getSortTableName($number);
+        //$tableAlias = $this->dbHandler->quoteIdentifier($tableAlias);
+
+        $query->leftJoin(
+            $query->alias(
+                $this->dbHandler->quoteTable('ezcontentobject_name'),
+                $tableAlias
+            ),
+            $query->expr->lAnd(
+                $query->expr->eq(
+                    $this->dbHandler->quoteColumn('id', 'ezcontentobject'),
+                    $this->dbHandler->quoteColumn('contentobject_id', $tableAlias)
+                ),
+                $query->expr->eq(
+                    $this->dbHandler->quoteColumn('current_version', 'ezcontentobject'),
+                    $this->dbHandler->quoteColumn('content_version', $tableAlias)
+                ),
+                $this->getLanguageCondition($query, $languageSettings, $tableAlias)
+            )
+        );
+    }
+
+    /**
+     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
+     * @param array $languageSettings
+     * @param string $contentNameTableAlias
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     *
+     * @return \Doctrine\DBAL\Query\Expression\CompositeExpression|string
+     */
+    protected function getLanguageCondition(
+        SelectQuery $query,
+        array $languageSettings,
+        string $contentNameTableAlias
+    ) {
+        // 1. Use main language(s) by default
+        if (empty($languageSettings['languages'])) {
+            return $query->expr->gt(
+                $query->expr->bitAnd(
+                    $this->dbHandler->quoteColumn('initial_language_id', 'ezcontentobject'),
+                    $this->dbHandler->quoteColumn('language_id', $contentNameTableAlias)
+                ),
+                $query->bindValue(0, null, PDO::PARAM_INT)
+            );
+        }
+
+        // 2. Otherwise use prioritized languages
+        $leftSide = $query->expr->bitAnd(
+            $query->expr->sub(
+                $this->dbHandler->quoteColumn('language_mask', 'ezcontentobject'),
+                $query->expr->bitAnd(
+                    $this->dbHandler->quoteColumn('language_mask', 'ezcontentobject'),
+                    $this->dbHandler->quoteColumn('language_id', $contentNameTableAlias)
+                )
+            ),
+            $query->bindValue(1, null, PDO::PARAM_INT)
+        );
+        $rightSide = $query->expr->bitAnd(
+            $this->dbHandler->quoteColumn('language_id', $contentNameTableAlias),
+            $query->bindValue(1, null, PDO::PARAM_INT)
+        );
+
+        for (
+            $index = count($languageSettings['languages']) - 1, $multiplier = 2;
+            $index >= 0;
+            $index--, $multiplier *= 2
+        ) {
+            $languageCode = $languageSettings['languages'][$index];
+            $languageId = $this->languageHandler->loadByLanguageCode($languageCode)->id;
+
+            $addToLeftSide = $query->expr->bitAnd(
+                $query->expr->sub(
+                    $this->dbHandler->quoteColumn('language_mask', 'ezcontentobject'),
+                    $query->expr->bitAnd(
+                        $this->dbHandler->quoteColumn('language_mask', 'ezcontentobject'),
+                        $this->dbHandler->quoteColumn('language_id', $contentNameTableAlias)
+                    )
+                ),
+                $query->bindValue($languageId, null, PDO::PARAM_INT)
+            );
+            $addToRightSide = $query->expr->bitAnd(
+                $this->dbHandler->quoteColumn('language_id', $contentNameTableAlias),
+                $query->bindValue($languageId, null, PDO::PARAM_INT)
+            );
+
+            if ($multiplier > $languageId) {
+                $factor = $multiplier / $languageId;
+                /** @noinspection PhpStatementHasEmptyBodyInspection */
+                /** @noinspection MissingOrEmptyGroupStatementInspection */
+                /** @noinspection LoopWhichDoesNotLoopInspection */
+                for ($shift = 0; $factor > 1; $factor /= 2, $shift++) {}
+                $factorTerm = ' << ' . $shift;
+                $addToLeftSide .= $factorTerm;
+                $addToRightSide .= $factorTerm;
+            } elseif ($multiplier < $languageId) {
+                $factor = $languageId / $multiplier;
+                /** @noinspection PhpStatementHasEmptyBodyInspection */
+                /** @noinspection MissingOrEmptyGroupStatementInspection */
+                /** @noinspection LoopWhichDoesNotLoopInspection */
+                for ($shift = 0; $factor > 1; $factor /= 2, $shift++) {}
+                $factorTerm = ' >> ' . $shift;
+                $addToLeftSide .= $factorTerm;
+                $addToRightSide .= $factorTerm;
+            }
+
+            $leftSide = $query->expr->add($leftSide, "($addToLeftSide)");
+            $rightSide = $query->expr->add($rightSide, "($addToRightSide)");
+        }
+
+        return $query->expr->lAnd(
+            $query->expr->gt(
+                $query->expr->bitAnd(
+                    $this->dbHandler->quoteColumn('language_mask', 'ezcontentobject'),
+                    $this->dbHandler->quoteColumn('language_id', $contentNameTableAlias)
+                ),
+                $query->bindValue(0, null, PDO::PARAM_INT)
+            ),
+            $query->expr->lt($leftSide, $rightSide)
+        );
+    }
+}

--- a/lib/Core/Search/Solr/FieldMapper/ContentTranslation/ContentNameFieldMapper.php
+++ b/lib/Core/Search/Solr/FieldMapper/ContentTranslation/ContentNameFieldMapper.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\FieldMapper\ContentTranslation;
+
+use eZ\Publish\SPI\Persistence\Content;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType\StringField;
+use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentTranslationFieldMapper;
+
+class ContentNameFieldMapper extends ContentTranslationFieldMapper
+{
+    public function accept(Content $content, $languageCode): bool
+    {
+        return true;
+    }
+
+    public function mapFields(Content $content, $languageCode): array
+    {
+        if (!isset($content->versionInfo->names[$languageCode])) {
+            return [];
+        }
+
+        return [
+            new Field(
+                'ng_content_name',
+                $content->versionInfo->names[$languageCode],
+                new StringField()
+            ),
+        ];
+    }
+}

--- a/lib/Core/Search/Solr/Query/Common/SortClauseVisitor/ContentName.php
+++ b/lib/Core/Search/Solr/Query/Common/SortClauseVisitor/ContentName.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\SortClauseVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+use EzSystems\EzPlatformSolrSearchEngine\Query\SortClauseVisitor;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\SortClause\ContentName as ContentNameClause;
+
+class ContentName extends SortClauseVisitor
+{
+    public function canVisit(SortClause $sortClause): bool
+    {
+        return $sortClause instanceof ContentNameClause;
+    }
+
+    public function visit(SortClause $sortClause): string
+    {
+        return 'ng_content_name_s' . $this->getDirection($sortClause);
+    }
+}

--- a/lib/Resources/config/search/legacy.yml
+++ b/lib/Resources/config/search/legacy.yml
@@ -111,3 +111,12 @@ services:
             - '@ezpublish.persistence.connection'
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+
+    netgen.search.legacy.query.common.sort_clause_handler.content_name:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Legacy\Query\Common\SortClauseHandler\ContentName
+        arguments:
+            - '@ezpublish.api.storage_engine.legacy.dbhandler'
+            - '@ezpublish.spi.persistence.language_handler'
+        tags:
+            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}
+            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}

--- a/lib/Resources/config/search/legacy.yml
+++ b/lib/Resources/config/search/legacy.yml
@@ -115,7 +115,7 @@ services:
     netgen.search.legacy.query.common.sort_clause_handler.content_name:
         class: Netgen\EzPlatformSearchExtra\Core\Search\Legacy\Query\Common\SortClauseHandler\ContentName
         arguments:
-            - '@ezpublish.api.storage_engine.legacy.dbhandler'
+            - '@ezpublish.persistence.connection'
             - '@ezpublish.spi.persistence.language_handler'
         tags:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}

--- a/lib/Resources/config/search/solr/field_mappers.yml
+++ b/lib/Resources/config/search/solr/field_mappers.yml
@@ -20,6 +20,11 @@ services:
         tags:
             - { name: ezpublish.search.solr.field_mapper.location }
 
+    netgen.search.solr.field_mapper.content_translation.content_name:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\FieldMapper\ContentTranslation\ContentNameFieldMapper
+        tags:
+            - { name: ezpublish.search.solr.field_mapper.block_translation }
+
     netgen.search.solr.field_mapper.content.content_and_location_id:
         class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\FieldMapper\Content\ContentAndLocationIdFieldMapper
         arguments:

--- a/lib/Resources/config/search/solr/sort_clause_visitors.yml
+++ b/lib/Resources/config/search/solr/sort_clause_visitors.yml
@@ -23,3 +23,9 @@ services:
         tags:
             - {name: ezpublish.search.solr.query.content.sort_clause_visitor}
             - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
+
+    netgen.search.solr.query.common.sort_clause_visitor.content_name:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\SortClauseVisitor\ContentName
+        tags:
+            - {name: ezpublish.search.solr.query.content.sort_clause_visitor}
+            - {name: ezpublish.search.solr.query.location.sort_clause_visitor}

--- a/tests/lib/Integration/API/ContentNameSortClauseTest.php
+++ b/tests/lib/Integration/API/ContentNameSortClauseTest.php
@@ -1,0 +1,388 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\Tests\Integration\API;
+
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeIdentifier;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentId;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause\SectionIdentifier;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+use eZ\Publish\API\Repository\Values\ValueObject;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\SortClause\ContentName;
+use RuntimeException;
+
+class ContentNameSortClauseTest extends BaseTest
+{
+    public function providerForTestFind(): array
+    {
+        return [
+            [
+                new LocationQuery([
+                    'filter' => new ContentTypeIdentifier('name_test'),
+                    'sortClauses' => [
+                        new ContentName(Query::SORT_ASC),
+                        new SectionIdentifier(),
+                    ],
+                ]),
+                ['eng-GB'],
+                false,
+                ['e1', 'e2', 'e4', 'e7'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new ContentTypeIdentifier('name_test'),
+                    'sortClauses' => [
+                        new SectionIdentifier(),
+                        new ContentName(Query::SORT_DESC),
+                    ],
+                ]),
+                ['eng-GB'],
+                false,
+                ['e7', 'e4', 'e2', 'e1'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new ContentTypeIdentifier('name_test'),
+                    'sortClauses' => [
+                        new ContentId(),
+                        new ContentName(Query::SORT_ASC),
+                    ],
+                ]),
+                ['eng-GB'],
+                true,
+                ['e1', 'e2', 'n3', 'e4', 'n5', 'e7'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new ContentTypeIdentifier('name_test'),
+                    'sortClauses' => [new ContentName(Query::SORT_ASC)],
+                ]),
+                ['eng-GB'],
+                true,
+                ['e1', 'e2', 'e4', 'e7', 'n3', 'n5'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new ContentTypeIdentifier('name_test'),
+                    'sortClauses' => [
+                        new ContentName(Query::SORT_DESC),
+                        new ContentId(),
+                    ],
+                ]),
+                ['eng-GB'],
+                true,
+                ['n5', 'n3', 'e7', 'e4', 'e2', 'e1'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new ContentTypeIdentifier('name_test'),
+                    'sortClauses' => [new ContentName(Query::SORT_ASC)],
+                ]),
+                ['nor-NO'],
+                false,
+                ['n2', 'n3', 'n5', 'n7'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new ContentTypeIdentifier('name_test'),
+                    'sortClauses' => [new ContentName(Query::SORT_DESC)],
+                ]),
+                ['nor-NO'],
+                false,
+                ['n7', 'n5', 'n3', 'n2'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new ContentTypeIdentifier('name_test'),
+                    'sortClauses' => [new ContentName(Query::SORT_ASC)],
+                ]),
+                ['ger-DE'],
+                false,
+                ['g1', 'g3', 'g6', 'g7'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new ContentTypeIdentifier('name_test'),
+                    'sortClauses' => [new ContentName(Query::SORT_DESC)],
+                ]),
+                ['ger-DE'],
+                false,
+                ['g7', 'g6', 'g3', 'g1'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new ContentTypeIdentifier('name_test'),
+                    'sortClauses' => [new ContentName(Query::SORT_ASC)],
+                ]),
+                ['ger-DE'],
+                true,
+                ['g1', 'g3', 'g6', 'g7', 'n2', 'n5'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new ContentTypeIdentifier('name_test'),
+                    'sortClauses' => [new ContentName(Query::SORT_DESC)],
+                ]),
+                ['ger-DE'],
+                true,
+                ['n5', 'n2', 'g7', 'g6', 'g3', 'g1'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new ContentTypeIdentifier('name_test'),
+                    'sortClauses' => [new ContentName(Query::SORT_ASC)],
+                ]),
+                ['eng-GB', 'ger-DE'],
+                false,
+                ['e1', 'e2', 'e4', 'e7', 'g3', 'g6'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new ContentTypeIdentifier('name_test'),
+                    'sortClauses' => [new ContentName(Query::SORT_DESC)],
+                ]),
+                ['eng-GB', 'ger-DE'],
+                false,
+                ['g6', 'g3', 'e7', 'e4', 'e2', 'e1'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new ContentTypeIdentifier('name_test'),
+                    'sortClauses' => [new ContentName(Query::SORT_ASC)],
+                ]),
+                ['ger-DE', 'eng-GB'],
+                false,
+                ['e2', 'e4', 'g1', 'g3', 'g6', 'g7'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new ContentTypeIdentifier('name_test'),
+                    'sortClauses' => [new ContentName(Query::SORT_DESC)],
+                ]),
+                ['ger-DE', 'eng-GB'],
+                false,
+                ['g7', 'g6', 'g3', 'g1', 'e4', 'e2'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new ContentTypeIdentifier('name_test'),
+                    'sortClauses' => [new ContentName(Query::SORT_ASC)],
+                ]),
+                ['ger-DE', 'eng-GB', 'nor-NO'],
+                false,
+                ['e2', 'e4', 'g1', 'g3', 'g6', 'g7', 'n5'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new ContentTypeIdentifier('name_test'),
+                    'sortClauses' => [new ContentName(Query::SORT_DESC)],
+                ]),
+                ['ger-DE', 'eng-GB', 'nor-NO'],
+                false,
+                ['n5', 'g7', 'g6', 'g3', 'g1', 'e4', 'e2'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new ContentTypeIdentifier('name_test'),
+                    'sortClauses' => [new ContentName(Query::SORT_ASC)],
+                ]),
+                ['ger-DE', 'nor-NO', 'eng-GB'],
+                false,
+                ['e4', 'g1', 'g3', 'g6', 'g7', 'n2', 'n5'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new ContentTypeIdentifier('name_test'),
+                    'sortClauses' => [new ContentName(Query::SORT_DESC)],
+                ]),
+                ['ger-DE', 'nor-NO', 'eng-GB'],
+                false,
+                ['n5', 'n2', 'g7', 'g6', 'g3', 'g1', 'e4'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new ContentTypeIdentifier('name_test'),
+                    'sortClauses' => [new ContentName(Query::SORT_ASC)],
+                ]),
+                ['nor-NO', 'ger-DE', 'eng-GB'],
+                false,
+                ['e4', 'g1', 'g6', 'n2', 'n3', 'n5', 'n7'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new ContentTypeIdentifier('name_test'),
+                    'sortClauses' => [new ContentName(Query::SORT_DESC)],
+                ]),
+                ['nor-NO', 'ger-DE', 'eng-GB'],
+                false,
+                ['n7', 'n5', 'n3', 'n2', 'g6', 'g1', 'e4'],
+            ],
+        ];
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function testPrepareTestFixtures(): void
+    {
+        $repository = $this->getRepository();
+        $contentService = $repository->getContentService();
+        $contentTypeService = $repository->getContentTypeService();
+        $locationService = $repository->getLocationService();
+        $languageService = $repository->getContentLanguageService();
+
+        $languageCreateStruct = $languageService->newLanguageCreateStruct();
+        $languageCreateStruct->name = 'Norwegian';
+        $languageCreateStruct->languageCode = 'nor-NO';
+        $languageService->createLanguage($languageCreateStruct);
+
+        $contentTypeGroups = $contentTypeService->loadContentTypeGroups();
+        $contentTypeCreateStruct = $contentTypeService->newContentTypeCreateStruct('name_test');
+        $contentTypeCreateStruct->mainLanguageCode = 'eng-GB';
+        $contentTypeCreateStruct->names = ['eng-GB' => 'Name test type'];
+        $contentTypeCreateStruct->nameSchema = '<title>';
+        $fieldDefinitionCreateStruct = $contentTypeService->newFieldDefinitionCreateStruct('title', 'ezstring');
+        $contentTypeCreateStruct->addFieldDefinition($fieldDefinitionCreateStruct);
+        $contentTypeDraft = $contentTypeService->createContentType($contentTypeCreateStruct, [reset($contentTypeGroups)]);
+        $contentTypeService->publishContentTypeDraft($contentTypeDraft);
+        $contentType = $contentTypeService->loadContentTypeByIdentifier('name_test');
+
+        $valueGroups = [
+            ['e1', 'g1'],
+            ['n2', 'e2'],
+            ['n3', 'g3'],
+            ['e4'],
+            ['n5'],
+            ['g6'],
+            ['n7', 'e7', 'g7'],
+        ];
+
+        $locationCreateStruct = $locationService->newLocationCreateStruct(2);
+
+        foreach ($valueGroups as $values) {
+            $mainValue = reset($values);
+            $mainLanguageCode = $this->resolveLanguageCode($mainValue);
+            $contentCreateStruct = $contentService->newContentCreateStruct($contentType, $mainLanguageCode);
+            $contentCreateStruct->alwaysAvailable = ($mainLanguageCode === 'nor-NO');
+
+            foreach ($values as $value) {
+                $languageCode = $this->resolveLanguageCode($value);
+                $contentCreateStruct->setField('title', $value, $languageCode);
+            }
+
+            $contentDraft = $contentService->createContent($contentCreateStruct, [$locationCreateStruct]);
+            $contentService->publishVersion($contentDraft->versionInfo);
+        }
+
+        $this->refreshSearch($repository);
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @dataProvider providerForTestFind
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     * @param string[] $languageCodes
+     * @param bool $useAlwaysAvailable
+     * @param array $expectedValues
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testFindContent(
+        Query $query,
+        array $languageCodes,
+        bool $useAlwaysAvailable,
+        array $expectedValues
+    ): void {
+        $searchService = $this->getSearchService(false);
+        $languageFilter = ['languages' => $languageCodes, 'useAlwaysAvailable' => $useAlwaysAvailable];
+
+        $searchResult = $searchService->findContent($query, $languageFilter);
+
+        $this->assertSearchResult($searchResult, $expectedValues);
+    }
+
+    /**
+     * @dataProvider providerForTestFind
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\LocationQuery $query
+     * @param string[] $languageCodes
+     * @param bool $useAlwaysAvailable
+     * @param array $expectedValues
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testFindLocations(
+        LocationQuery $query,
+        array $languageCodes,
+        bool $useAlwaysAvailable,
+        array $expectedValues
+    ): void {
+        $searchService = $this->getSearchService(false);
+        $languageFilter = ['languages' => $languageCodes, 'useAlwaysAvailable' => $useAlwaysAvailable];
+
+        $searchResult = $searchService->findLocations($query, $languageFilter);
+
+        $this->assertSearchResult($searchResult, $expectedValues);
+    }
+
+    protected function assertSearchResult(SearchResult $searchResult, array $expectedValues): void
+    {
+        self::assertCount(count($expectedValues), $searchResult->searchHits);
+        $actualValues = [];
+        $actualNames = [];
+
+        foreach ($expectedValues as $index => $value) {
+            $searchHit = $searchResult->searchHits[$index];
+            $content = $this->getContent($searchHit->valueObject);
+            $languageCode = $this->resolveLanguageCode($value);
+            /** @var \eZ\Publish\Core\FieldType\TextLine\Value $fieldValue */
+            $fieldValue = $content->getFieldValue('title', $languageCode);
+
+            $actualValues[] = $fieldValue->text ?? null;
+            $actualNames[] = $content->getName($languageCode);
+        }
+
+        self::assertEquals($expectedValues, $actualValues);
+        self::assertEquals($expectedValues, $actualNames);
+    }
+
+    protected function getContent(ValueObject $valueObject): Content
+    {
+        if ($valueObject instanceof Content) {
+            return $valueObject;
+        }
+
+        if ($valueObject instanceof Location) {
+            return $valueObject->getContent();
+        }
+
+        throw new RuntimeException('Could not resolve Content');
+    }
+
+    protected function resolveLanguageCode(string $value): string
+    {
+        switch ($value[0]) {
+            case 'n';
+                return 'nor-NO';
+            case 'e';
+                return 'eng-GB';
+            case 'g';
+                return 'ger-DE';
+        }
+
+        throw new RuntimeException('Could not resolve language code');
+    }
+}


### PR DESCRIPTION
Counterpart of #44 for 2.x line.

In difference to the `ContentName` sort clause from kernel, this one operates on the Content name for the matched translation, and not on the Content's name in the main language. Implemented for both Solr and Legacy search engines.