### PR TITLE
NGSTACK-444: Implement ContentName criterion

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Only a list of features is provided here, see
 [documentation](https://netgen-ezplatform-search-extra.readthedocs.io)
 for more details.
 
-- [`ContentName`](https://github.com/netgen/ezplatform-search-extra/blob/1.13/lib/API/Values/Content/Query/SortClause/ContentName.php) sort that works on matched translation's Content name  (`solr`, `legacy`)
+- [`ContentName`](https://github.com/netgen/ezplatform-search-extra/blob/1.13/lib/API/Values/Content/Query/Criterion/ContentName.php) criterion that works on matched translation's Content name  (`solr`, `legacy`)
+
+- [`ContentName`](https://github.com/netgen/ezplatform-search-extra/blob/1.13/lib/API/Values/Content/Query/SortClause/ContentName.php) sort clause that works on matched translation's Content name  (`solr`, `legacy`)
 
 - [`ContentId`](https://github.com/netgen/ezplatform-search-extra/blob/1.13/lib/API/Values/Content/Query/Criterion/ContentId.php) and [`LocationId`](https://github.com/netgen/ezplatform-search-extra/blob/1.13/lib/API/Values/Content/Query/Criterion/LocationId.php) criteria with support for range operators  (`solr`, `legacy`)
 
@@ -115,7 +117,7 @@ for more details.
 To install eZ Platform Search Extra first add it as a dependency to your project:
 
 ```sh
-composer require netgen/ezplatform-search-extra:^1.8
+composer require netgen/ezplatform-search-extra:^1.14
 ```
 
 Once the added dependency is installed, activate the bundle in `app/AppKernel.php` file by adding it to the `$bundles` array in `registerBundles()` method, together with other required bundles:

--- a/lib/API/Values/Content/Query/Criterion/ContentName.php
+++ b/lib/API/Values/Content/Query/Criterion/ContentName.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
+
+/**
+ * A criterion that matches Content matched translation's Content name.
+ */
+class ContentName extends Criterion
+{
+    /**
+     * @param string $operator One of the Operator constants
+     * @param string|string[] $value One or more Content names that must be matched
+     */
+    public function __construct(string $operator, $value)
+    {
+        parent::__construct(null, $operator, $value);
+    }
+
+    public function getSpecifications(): array
+    {
+        return [
+            new Specifications(Operator::EQ, Specifications::FORMAT_SINGLE, Specifications::TYPE_STRING),
+            new Specifications(Operator::IN, Specifications::FORMAT_ARRAY, Specifications::TYPE_STRING),
+            new Specifications(Operator::GT, Specifications::FORMAT_SINGLE, Specifications::TYPE_STRING),
+            new Specifications(Operator::GTE, Specifications::FORMAT_SINGLE, Specifications::TYPE_STRING),
+            new Specifications(Operator::LT, Specifications::FORMAT_SINGLE, Specifications::TYPE_STRING),
+            new Specifications(Operator::LTE, Specifications::FORMAT_SINGLE, Specifications::TYPE_STRING),
+            new Specifications(Operator::LIKE, Specifications::FORMAT_SINGLE, Specifications::TYPE_STRING),
+            new Specifications(Operator::BETWEEN, Specifications::FORMAT_ARRAY, Specifications::TYPE_STRING, 2),
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
+     */
+    public static function createFromQueryBuilder($target, $operator, $value)
+    {
+        @trigger_error(
+            'The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.',
+            E_USER_DEPRECATED
+        );
+
+        return new self($operator, $value);
+    }
+}

--- a/lib/Core/Search/Solr/Query/Common/CriterionVisitor/ContentNameIn.php
+++ b/lib/Core/Search/Solr/Query/Common/CriterionVisitor/ContentNameIn.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\ContentName;
+
+/**
+ * Visits the ContentName criterion.
+ *
+ * @see \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\ContentName
+ */
+final class ContentNameIn extends CriterionVisitor
+{
+    public function canVisit(Criterion $criterion): bool
+    {
+        return
+            $criterion instanceof ContentName
+            && (
+                $criterion->operator === Operator::IN
+                || $criterion->operator === Operator::EQ
+            );
+    }
+
+    public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null): string
+    {
+        $values = [];
+
+        foreach ($criterion->value as $value) {
+            $values[] = 'ng_content_name_s:"' . $this->escapeQuote($value, true) . '"';
+        }
+
+        return '(' . implode(' OR ', $values) . ')';
+    }
+}

--- a/lib/Core/Search/Solr/Query/Common/CriterionVisitor/ContentNameLike.php
+++ b/lib/Core/Search/Solr/Query/Common/CriterionVisitor/ContentNameLike.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\ContentName;
+
+/**
+ * Visits the ContentName criterion.
+ *
+ * @see \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\ContentName
+ */
+class ContentNameLike extends CriterionVisitor
+{
+    public function canVisit(Criterion $criterion): bool
+    {
+        return $criterion instanceof ContentName && $criterion->operator === Operator::LIKE;
+    }
+
+    public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null): string
+    {
+        $value = $criterion->value[0];
+
+        if (strpos($value, '*') !== false) {
+            return 'ng_content_name_s:' . $this->escapeExpressions($value, true);
+        }
+
+        return 'ng_content_name_s:"' . $this->escapeQuote($value) . '"';
+    }
+}

--- a/lib/Core/Search/Solr/Query/Common/CriterionVisitor/ContentNameRange.php
+++ b/lib/Core/Search/Solr/Query/Common/CriterionVisitor/ContentNameRange.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\ContentName;
+
+/**
+ * Visits the ContentName criterion.
+ *
+ * @see \Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\ContentName
+ */
+final class ContentNameRange extends CriterionVisitor
+{
+    public function canVisit(Criterion $criterion): bool
+    {
+        return
+            $criterion instanceof ContentName
+            && (
+                $criterion->operator === Operator::LT
+                || $criterion->operator === Operator::LTE
+                || $criterion->operator === Operator::GT
+                || $criterion->operator === Operator::GTE
+                || $criterion->operator === Operator::BETWEEN
+            );
+    }
+
+    public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null): string
+    {
+        $start = $criterion->value[0];
+        $end = $criterion->value[1] ?? null;
+
+        if ($criterion->operator === Operator::LT || $criterion->operator === Operator::LTE) {
+            $end = $start;
+            $start = null;
+        }
+
+        return 'ng_content_name_s:' . $this->getRange($criterion->operator, $start, $end);
+    }
+}

--- a/lib/Resources/config/search/legacy.yml
+++ b/lib/Resources/config/search/legacy.yml
@@ -74,6 +74,15 @@ services:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
+    netgen.search.legacy.query.common.criterion_handler.content_name:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Legacy\Query\Common\CriterionHandler\ContentName
+        arguments:
+            - '@ezpublish.api.storage_engine.legacy.dbhandler'
+            - '@ezpublish.spi.persistence.language_handler'
+        tags:
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+
     netgen.search.legacy.query.content.criterion_visitor.location_id:
         class: Netgen\EzPlatformSearchExtra\Core\Search\Legacy\Query\Content\CriterionHandler\LocationId
         arguments:

--- a/lib/Resources/config/search/solr/criterion_visitors.yml
+++ b/lib/Resources/config/search/solr/criterion_visitors.yml
@@ -74,3 +74,21 @@ services:
         class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Location\CriterionVisitor\LocationIdBetween
         tags:
             - { name: ezpublish.search.solr.query.location.criterion_visitor }
+
+    netgen.search.solr.query.common.criterion_visitor.content_name_in:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor\ContentNameIn
+        tags:
+            - { name: ezpublish.search.solr.query.content.criterion_visitor }
+            - { name: ezpublish.search.solr.query.location.criterion_visitor }
+
+    netgen.search.solr.query.common.criterion_visitor.content_name_like:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor\ContentNameLike
+        tags:
+            - { name: ezpublish.search.solr.query.content.criterion_visitor }
+            - { name: ezpublish.search.solr.query.location.criterion_visitor }
+
+    netgen.search.solr.query.common.criterion_visitor.content_name_range:
+        class: Netgen\EzPlatformSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor\ContentNameRange
+        tags:
+            - { name: ezpublish.search.solr.query.content.criterion_visitor }
+            - { name: ezpublish.search.solr.query.location.criterion_visitor }

--- a/tests/lib/Integration/API/ContentNameCriterionTest.php
+++ b/tests/lib/Integration/API/ContentNameCriterionTest.php
@@ -1,0 +1,403 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\EzPlatformSearchExtra\Tests\Integration\API;
+
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeIdentifier;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalOr;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentId;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause\SectionIdentifier;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+use eZ\Publish\API\Repository\Values\ValueObject;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\Criterion\ContentName;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Query\SortClause\ContentName as ContentNameSortClause;
+use RuntimeException;
+
+class ContentNameCriterionTest extends BaseTest
+{
+    public function providerForTestFind(): array
+    {
+        return [
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new ContentTypeIdentifier('name_test'),
+                        new ContentName(Operator::EQ, 'ev2'),
+                    ]),
+                    'sortClauses' => [
+                        new ContentNameSortClause(Query::SORT_ASC),
+                        new SectionIdentifier(),
+                    ],
+                ]),
+                ['eng-GB'],
+                false,
+                ['ev2'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new ContentTypeIdentifier('name_test'),
+                        new ContentName(Operator::GT, 'ev2'),
+                    ]),
+                    'sortClauses' => [
+                        new SectionIdentifier(),
+                        new ContentNameSortClause(Query::SORT_DESC),
+                    ],
+                ]),
+                ['eng-GB'],
+                false,
+                ['ev7', 'ev4'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new ContentTypeIdentifier('name_test'),
+                        new ContentName(Operator::GTE, 'nx3'),
+                    ]),
+                    'sortClauses' => [
+                        new ContentId(),
+                        new ContentNameSortClause(Query::SORT_ASC),
+                    ],
+                ]),
+                ['eng-GB'],
+                true,
+                ['nx3', 'nx5'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new ContentTypeIdentifier('name_test'),
+                        new ContentName(Operator::LT, 'ev4'),
+                    ]),
+                    'sortClauses' => [new ContentNameSortClause(Query::SORT_ASC)],
+                ]),
+                ['eng-GB'],
+                true,
+                ['ev1', 'ev2'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new ContentTypeIdentifier('name_test'),
+                        new ContentName(Operator::LTE, 'nx3'),
+                    ]),
+                    'sortClauses' => [
+                        new ContentNameSortClause(Query::SORT_DESC),
+                        new ContentId(),
+                    ],
+                ]),
+                ['eng-GB'],
+                true,
+                ['nx3', 'ev7', 'ev4', 'ev2', 'ev1'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new ContentTypeIdentifier('name_test'),
+                        new ContentName(Operator::BETWEEN, ['nx2', 'nx5']),
+                    ]),
+                    'sortClauses' => [new ContentNameSortClause(Query::SORT_ASC)],
+                ]),
+                ['nor-NO'],
+                false,
+                ['nx2', 'nx3', 'nx5'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new ContentTypeIdentifier('name_test'),
+                        new ContentName(Operator::GT, 'nx2'),
+                        new ContentName(Operator::LTE, 'nx5'),
+                    ]),
+                    'sortClauses' => [new ContentNameSortClause(Query::SORT_DESC)],
+                ]),
+                ['nor-NO'],
+                false,
+                ['nx5', 'nx3'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new ContentTypeIdentifier('name_test'),
+                        new ContentName(Operator::LT, 'gx6'),
+                        new ContentName(Operator::LIKE, 'gx*'),
+                    ]),
+                    'sortClauses' => [new ContentNameSortClause(Query::SORT_ASC)],
+                ]),
+                ['ger-DE'],
+                false,
+                ['gx1', 'gx3'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new ContentTypeIdentifier('name_test'),
+                        new LogicalOr([
+                            new ContentName(Operator::LIKE, '*3'),
+                            new ContentName(Operator::LIKE, '*6'),
+                        ])
+                    ]),
+                    'sortClauses' => [new ContentNameSortClause(Query::SORT_DESC)],
+                ]),
+                ['ger-DE'],
+                false,
+                ['gx6', 'gx3'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new ContentTypeIdentifier('name_test'),
+                        new ContentName(Operator::LIKE, '*n*'),
+                    ]),
+                    'sortClauses' => [new ContentNameSortClause(Query::SORT_ASC)],
+                ]),
+                ['ger-DE'],
+                true,
+                ['nx2', 'nx5'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new ContentTypeIdentifier('name_test'),
+                        new ContentName(Operator::LIKE, '*v*'),
+                    ]),
+                    'sortClauses' => [new ContentNameSortClause(Query::SORT_ASC)],
+                ]),
+                ['eng-GB'],
+                true,
+                ['ev1', 'ev2', 'ev4', 'ev7'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new ContentTypeIdentifier('name_test'),
+                        new ContentName(Operator::LIKE, 'nx*'),
+                        new ContentName(Operator::GT, 'gx6'),
+                    ]),
+                    'sortClauses' => [new ContentNameSortClause(Query::SORT_DESC)],
+                ]),
+                ['ger-DE'],
+                true,
+                ['nx5', 'nx2'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new ContentTypeIdentifier('name_test'),
+                        new ContentName(Operator::IN, ['ev2']),
+                    ]),
+                    'sortClauses' => [new ContentNameSortClause(Query::SORT_ASC)],
+                ]),
+                ['eng-GB', 'ger-DE'],
+                false,
+                ['ev2'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new ContentTypeIdentifier('name_test'),
+                        new ContentName(Operator::IN, ['gx6', 'ev7', 'ev1']),
+                    ]),
+                    'sortClauses' => [new ContentNameSortClause(Query::SORT_DESC)],
+                ]),
+                ['eng-GB', 'ger-DE'],
+                false,
+                ['gx6', 'ev7', 'ev1'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new ContentTypeIdentifier('name_test'),
+                        new ContentName(Operator::IN, ['gx6', 'ev2', 'gx7', 'ev4']),
+                        new ContentName(Operator::GTE, 'ev4'),
+                    ]),
+                    'sortClauses' => [new ContentNameSortClause(Query::SORT_ASC)],
+                ]),
+                ['ger-DE', 'eng-GB'],
+                false,
+                ['ev4', 'gx6', 'gx7'],
+            ],
+            [
+                new LocationQuery([
+                    'filter' => new LogicalAnd([
+                        new ContentTypeIdentifier('name_test'),
+                        new ContentName(Operator::IN, ['gx6', 'gx3', 'ev4']),
+                        new ContentName(Operator::IN, ['gx1', 'ev4', 'ev2']),
+                    ]),
+                    'sortClauses' => [new ContentNameSortClause(Query::SORT_DESC)],
+                ]),
+                ['ger-DE', 'eng-GB'],
+                false,
+                ['ev4'],
+            ],
+        ];
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function testPrepareTestFixtures(): void
+    {
+        $repository = $this->getRepository();
+        $contentService = $repository->getContentService();
+        $contentTypeService = $repository->getContentTypeService();
+        $locationService = $repository->getLocationService();
+        $languageService = $repository->getContentLanguageService();
+
+        $languageCreateStruct = $languageService->newLanguageCreateStruct();
+        $languageCreateStruct->name = 'Norwegian';
+        $languageCreateStruct->languageCode = 'nor-NO';
+        $languageService->createLanguage($languageCreateStruct);
+
+        $contentTypeGroups = $contentTypeService->loadContentTypeGroups();
+        $contentTypeCreateStruct = $contentTypeService->newContentTypeCreateStruct('name_test');
+        $contentTypeCreateStruct->mainLanguageCode = 'eng-GB';
+        $contentTypeCreateStruct->names = ['eng-GB' => 'Name test type'];
+        $contentTypeCreateStruct->nameSchema = '<title>';
+        $fieldDefinitionCreateStruct = $contentTypeService->newFieldDefinitionCreateStruct('title', 'ezstring');
+        $contentTypeCreateStruct->addFieldDefinition($fieldDefinitionCreateStruct);
+        $contentTypeDraft = $contentTypeService->createContentType($contentTypeCreateStruct, [reset($contentTypeGroups)]);
+        $contentTypeService->publishContentTypeDraft($contentTypeDraft);
+        $contentType = $contentTypeService->loadContentTypeByIdentifier('name_test');
+
+        $valueGroups = [
+            ['ev1', 'gx1'],
+            ['nx2', 'ev2'],
+            ['nx3', 'gx3'],
+            ['ev4'],
+            ['nx5'],
+            ['gx6'],
+            ['nx7', 'ev7', 'gx7'],
+        ];
+
+        $locationCreateStruct = $locationService->newLocationCreateStruct(2);
+
+        foreach ($valueGroups as $values) {
+            $mainValue = reset($values);
+            $mainLanguageCode = $this->resolveLanguageCode($mainValue);
+            $contentCreateStruct = $contentService->newContentCreateStruct($contentType, $mainLanguageCode);
+            $contentCreateStruct->alwaysAvailable = ($mainLanguageCode === 'nor-NO');
+
+            foreach ($values as $value) {
+                $languageCode = $this->resolveLanguageCode($value);
+                $contentCreateStruct->setField('title', $value, $languageCode);
+            }
+
+            $contentDraft = $contentService->createContent($contentCreateStruct, [$locationCreateStruct]);
+            $contentService->publishVersion($contentDraft->versionInfo);
+        }
+
+        $this->refreshSearch($repository);
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @dataProvider providerForTestFind
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     * @param string[] $languageCodes
+     * @param bool $useAlwaysAvailable
+     * @param array $expectedValues
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testFindContent(
+        Query $query,
+        array $languageCodes,
+        bool $useAlwaysAvailable,
+        array $expectedValues
+    ): void {
+        $searchService = $this->getSearchService(false);
+        $languageFilter = ['languages' => $languageCodes, 'useAlwaysAvailable' => $useAlwaysAvailable];
+
+        $searchResult = $searchService->findContent($query, $languageFilter);
+
+        $this->assertSearchResult($searchResult, $expectedValues);
+    }
+
+    /**
+     * @dataProvider providerForTestFind
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\LocationQuery $query
+     * @param string[] $languageCodes
+     * @param bool $useAlwaysAvailable
+     * @param array $expectedValues
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testFindLocations(
+        LocationQuery $query,
+        array $languageCodes,
+        bool $useAlwaysAvailable,
+        array $expectedValues
+    ): void {
+        $searchService = $this->getSearchService(false);
+        $languageFilter = ['languages' => $languageCodes, 'useAlwaysAvailable' => $useAlwaysAvailable];
+
+        $searchResult = $searchService->findLocations($query, $languageFilter);
+
+        $this->assertSearchResult($searchResult, $expectedValues);
+    }
+
+    protected function assertSearchResult(SearchResult $searchResult, array $expectedValues): void
+    {
+        self::assertCount(count($expectedValues), $searchResult->searchHits);
+        $actualValues = [];
+        $actualNames = [];
+
+        foreach ($expectedValues as $index => $value) {
+            $searchHit = $searchResult->searchHits[$index];
+            $content = $this->getContent($searchHit->valueObject);
+            $languageCode = $this->resolveLanguageCode($value);
+            /** @var \eZ\Publish\Core\FieldType\TextLine\Value $fieldValue */
+            $fieldValue = $content->getFieldValue('title', $languageCode);
+
+            $actualValues[] = $fieldValue->text ?? null;
+            $actualNames[] = $content->getName($languageCode);
+        }
+
+        self::assertEquals($expectedValues, $actualValues);
+        self::assertEquals($expectedValues, $actualNames);
+    }
+
+    protected function getContent(ValueObject $valueObject): Content
+    {
+        if ($valueObject instanceof Content) {
+            return $valueObject;
+        }
+
+        if ($valueObject instanceof Location) {
+            return $valueObject->getContent();
+        }
+
+        throw new RuntimeException('Could not resolve Content');
+    }
+
+    protected function resolveLanguageCode(string $value): string
+    {
+        switch ($value[0]) {
+            case 'n';
+                return 'nor-NO';
+            case 'e';
+                return 'eng-GB';
+            case 'g';
+                return 'ger-DE';
+        }
+
+        throw new RuntimeException('Could not resolve language code');
+    }
+}


### PR DESCRIPTION
In difference to the ContentName criterion from kernel, this one operates on the Content name for the matched translation, and not on the Content's name in the main language. Implemented for both Solr and Legacy search engines.