### PR TITLE
[BUGFIX] $pager->getAdapter()->getSuggestion() returns null instead of Suggestion, if the solr is not configured

### DIFF
--- a/lib/Core/Pagination/Pagerfanta/BaseAdapter.php
+++ b/lib/Core/Pagination/Pagerfanta/BaseAdapter.php
@@ -135,7 +135,11 @@ abstract class BaseAdapter implements AdapterInterface, SearchResultExtras
         $this->facets = $searchResult->facets;
         $this->maxScore = $searchResult->maxScore;
         $this->nbResults = $searchResult->totalCount;
-        $this->suggestion = $searchResult instanceof ExtraSearchResult ? $searchResult->suggestion : new Suggestion([]);
+        $this->suggestion = new Suggestion([]);
+
+        if ($searchResult instanceof ExtraSearchResult && $searchResult->suggestion instanceof Suggestion) {
+            $this->suggestion = $searchResult->suggestion;
+        }
 
         $this->isExtraInfoInitialized = true;
     }


### PR DESCRIPTION
This fix initializes suggestion property with an empty object, and makes sure that the SearchResult suggestion property actually contains Suggestion object.

This bug occurs when you activate and use SearchResultExtras adapter, but the suggest/spellcheck feature in Solr is not yet activated following these instructions:
https://docs.netgen.io/projects/search-extra/en/latest/reference/spellcheck_suggestions.html

In this scenario, Netgen\EzPlatformSearchExtra\API\Values\Content\Search\SearchResult value of the "suggestion" property will be set to null instead of an empty Suggestion object, causing exception if we presume we have the Suggestion object in the property, or by passing it to some methods that expect the Suggestion instance argument (e.g Netgen\Bundle\SiteBundle\Core\Search\SuggestionResolver::getSuggestedSearchTerm(Query $query, Suggestion $suggestion).