### PR TITLE
Lock eZ Platform version to 3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "ezsystems/ezplatform-kernel": "^1.1",
+        "ezsystems/ezplatform-kernel": "~1.1",
         "ext-json": "*",
         "ext-dom": "*"
     },


### PR DESCRIPTION
Since eZ Platform 3.2 brings some breaking changes, this locks the `2.4.x` line to kernel `1.1.x`.

Kernel `>=1.2` will be supported by `2.5` and up.