### PR TITLE
NGSTACK-489 Extra solr fields

### DIFF
--- a/docs/reference/extra_fields.rst
+++ b/docs/reference/extra_fields.rst
@@ -10,7 +10,7 @@ This feature allows you to extract additionally indexed Solr fields from each Se
 1. Usage
 ~~~~~~~~
 
-In order for this functionality to work, you have to use overridden `Netgen\EzPlatformSearchExtra\API\Values\Content\Search\Query` or `Netgen\EzPlatformSearchExtra\API\Values\Content\Search\LocationQuery` queries and use it's property `extraFields` provide a list of additional fields that you want to extract from the Solr document. Those fields, if exist, and their values will appear in the `extraFields` property of each `SearchHit` object contained in the `SearchResult.`
+In order for this functionality to work, you have to use overridden `Netgen\EzPlatformSearchExtra\API\Values\Content\Search\Query` or `Netgen\EzPlatformSearchExtra\API\Values\Content\Search\LocationQuery` queries and use it's property `extraFields` to provide a list of additional fields that you want to extract from the Solr document. Those fields, if exist, and their values will appear in the `extraFields` property of each `SearchHit` object contained in the `SearchResult.`
 
 2. Example
 ~~~~~~~~~~

--- a/docs/reference/extra_fields.rst
+++ b/docs/reference/extra_fields.rst
@@ -1,0 +1,56 @@
+Extra fields from Solr
+======================
+
+This feature allows you to extract additionally indexed Solr fields from each SearchHit in SearchResult. For example, you can index some fields from children content on the parent content and then get those fields during search (eg. children count).
+
+.. note::
+
+    This feature is available only with the Solr search engine.
+
+1. Usage
+~~~~~~~~
+
+In order for this functionality to work, you have to use overridden `Netgen\EzPlatformSearchExtra\API\Values\Content\Search\Query` or `Netgen\EzPlatformSearchExtra\API\Values\Content\Search\LocationQuery` queries and use it's property `extraFields` provide a list of additional fields that you want to extract from the Solr document. Those fields, if exist, and their values will appear in the `extraFields` property of each `SearchHit` object contained in the `SearchResult.`
+
+2. Example
+~~~~~~~~~~
+
+Example of a content field mapper:
+
+.. code-block:: php
+
+    public function mapFields(SPIContent $content)
+    {
+        return [
+            new Field(
+                'extra_field_example',
+                5,
+                new IntegerField()
+            ),
+        ];
+    }
+
+Search example:
+
+.. code-block:: php
+
+    /** @var \Netgen\EzPlatformSearchExtra\API\Values\Content\Search\Query $query **/
+    $query = new Query();
+
+    $query->extraFields = [
+        'extra_field_example_i',
+    ];
+
+    /** @var \Netgen\EzPlatformSiteApi\API\FindService $findService **/
+    $searchResult = $findService->findContent($query);
+
+    /** @var \Netgen\EzPlatformSearchExtra\API\Values\Content\Search\SearchHit $searchHit **/
+    foreach ($searchResult->searchHits as $searchHit) {
+        var_dump($searchHit->extraFields);
+    }
+
+This will output the following data:
+
+.. code-block:: shell
+
+    array(1) { ["extra_field_example_i"]=> int(5) }

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -9,5 +9,6 @@ Reference
     random_sort
     subdocuments
     spellcheck_suggestions
+    extra_fields
 
 .. include:: /reference/map.rst.inc

--- a/lib/API/Values/Content/Search/LocationQuery.php
+++ b/lib/API/Values/Content/Search/LocationQuery.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\API\Values\Content\Search;
+
+use eZ\Publish\API\Repository\Values\Content\LocationQuery as BaseLocationQuery;
+
+class LocationQuery extends BaseLocationQuery
+{
+    /**
+     * List of additional fields that should be
+     * extracted from the Solr document for each hit.
+     *
+     * @var string[]
+     */
+    public $extraFields;
+}

--- a/lib/API/Values/Content/Search/Query.php
+++ b/lib/API/Values/Content/Search/Query.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\API\Values\Content\Search;
+
+use eZ\Publish\API\Repository\Values\Content\Query as BaseQuery;
+
+class Query extends BaseQuery
+{
+    /**
+     * List of additional fields that should be
+     * extracted from the Solr document for each hit.
+     *
+     * @var string[]
+     */
+    public $extraFields;
+}

--- a/lib/API/Values/Content/Search/SearchHit.php
+++ b/lib/API/Values/Content/Search/SearchHit.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\API\Values\Content\Search;
+
+use eZ\Publish\API\Repository\Values\Content\Search\SearchHit as BaseSearchHit;
+
+class SearchHit extends BaseSearchHit
+{
+    /**
+     * Additional fields from Solr document.
+     *
+     * @var array
+     */
+    public $extraFields;
+}

--- a/lib/Core/Search/Solr/ResultExtractor.php
+++ b/lib/Core/Search/Solr/ResultExtractor.php
@@ -25,7 +25,7 @@ abstract class ResultExtractor Extends BaseResultExtractor
             $searchResult->searchHits[$key] = new SearchHit(get_object_vars($searchHit));
             $searchResult->searchHits[$key]->extraFields = [];
 
-            if ($query instanceof ExtraQuery || $query instanceof ExtraLocationQuery) {
+            if ($query instanceof ExtraQuery || $query instanceof ExtraLocationQuery && is_array($query->extraFields)) {
                 $searchResult->searchHits[$key]->extraFields = $this->extractExtraFields(
                     $data,
                     $searchResult->searchHits[$key],

--- a/lib/Core/Search/Solr/ResultExtractor.php
+++ b/lib/Core/Search/Solr/ResultExtractor.php
@@ -2,8 +2,13 @@
 
 namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr;
 
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor as BaseResultExtractor;
 use Netgen\EzPlatformSearchExtra\Core\Search\Solr\API\FacetBuilder\RawFacetBuilder;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Search\Query as ExtraQuery;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Search\LocationQuery as ExtraLocationQuery;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Search\SearchHit;
 
 /**
  * This DocumentMapper implementation adds support for handling RawFacetBuilders.
@@ -12,9 +17,22 @@ use Netgen\EzPlatformSearchExtra\Core\Search\Solr\API\FacetBuilder\RawFacetBuild
  */
 abstract class ResultExtractor Extends BaseResultExtractor
 {
-    public function extract($data, array $facetBuilders = [])
+    public function extract($data, array $facetBuilders = [], ?Query $query = null)
     {
         $searchResult = $this->extractSearchResult($data, $facetBuilders);
+
+        foreach ($searchResult->searchHits as $key => $searchHit) {
+            $searchResult->searchHits[$key] = new SearchHit(get_object_vars($searchHit));
+            $searchResult->searchHits[$key]->extraFields = [];
+
+            if ($query instanceof ExtraQuery || $query instanceof ExtraLocationQuery) {
+                $searchResult->searchHits[$key]->extraFields = $this->extractExtraFields(
+                    $data,
+                    $searchResult->searchHits[$key],
+                    $query->extraFields
+                );
+            }
+        }
 
         if (!isset($data->facets) || $data->facets->count === 0) {
             return $searchResult;
@@ -56,5 +74,27 @@ abstract class ResultExtractor Extends BaseResultExtractor
                 return $facetBuilder instanceof RawFacetBuilder;
             }
         );
+    }
+
+    /**
+     * @param mixed $data
+     * @param \Netgen\EzPlatformSearchExtra\API\Values\Content\Search\SearchHit $searchResult
+     * @param string[] $extraFields
+     */
+    private function extractExtraFields($data, SearchHit $searchHit, $extraFields)
+    {
+        $extractedExtraFields = [];
+        foreach ($data->response->docs as $doc) {
+            if ($doc->document_type_id === 'content' && $doc->content_id_id == $searchHit->valueObject->id
+            || $doc->document_type_id === 'location' && $doc->location_id_id == $searchHit->valueObject->mainLocationId) {
+                foreach ($extraFields as $extraField) {
+                    if (property_exists($doc, $extraField)) {
+                        $extractedExtraFields[$extraField] = $doc->{$extraField};
+                    }
+                }
+            }
+        }
+
+        return $extractedExtraFields;
     }
 }

--- a/lib/Core/Search/Solr/ResultExtractor.php
+++ b/lib/Core/Search/Solr/ResultExtractor.php
@@ -24,7 +24,7 @@ abstract class ResultExtractor Extends BaseResultExtractor
             $searchResult->searchHits[$key] = new SearchHit(get_object_vars($searchHit));
             $searchResult->searchHits[$key]->extraFields = [];
 
-            if ($query instanceof ExtraQuery || $query instanceof ExtraLocationQuery && is_array($query->extraFields)) {
+            if (($query instanceof ExtraQuery || $query instanceof ExtraLocationQuery) && is_array($query->extraFields)) {
                 $searchResult->searchHits[$key]->extraFields = $this->extractExtraFields(
                     $data,
                     $searchResult->searchHits[$key],

--- a/lib/Core/Search/Solr/ResultExtractor.php
+++ b/lib/Core/Search/Solr/ResultExtractor.php
@@ -2,7 +2,6 @@
 
 namespace Netgen\EzPlatformSearchExtra\Core\Search\Solr;
 
-use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor as BaseResultExtractor;
 use Netgen\EzPlatformSearchExtra\Core\Search\Solr\API\FacetBuilder\RawFacetBuilder;
 use eZ\Publish\API\Repository\Values\Content\Query;
@@ -78,15 +77,17 @@ abstract class ResultExtractor Extends BaseResultExtractor
 
     /**
      * @param mixed $data
-     * @param \Netgen\EzPlatformSearchExtra\API\Values\Content\Search\SearchHit $searchResult
+     * @param \Netgen\EzPlatformSearchExtra\API\Values\Content\Search\SearchHit $searchHit
      * @param string[] $extraFields
+     *
+     * @return array
      */
     private function extractExtraFields($data, SearchHit $searchHit, $extraFields)
     {
         $extractedExtraFields = [];
         foreach ($data->response->docs as $doc) {
             if ($doc->document_type_id === 'content' && $doc->content_id_id == $searchHit->valueObject->id
-            || $doc->document_type_id === 'location' && $doc->location_id_id == $searchHit->valueObject->mainLocationId) {
+            || $doc->document_type_id === 'location' && $doc->location_id == $searchHit->valueObject->id) {
                 foreach ($extraFields as $extraField) {
                     if (property_exists($doc, $extraField)) {
                         $extractedExtraFields[$extraField] = $doc->{$extraField};

--- a/phpunit-integration-legacy.xml
+++ b/phpunit-integration-legacy.xml
@@ -16,6 +16,7 @@
             <exclude>tests/lib/Integration/API/IsFieldEmptyCriterionTest.php</exclude>
             <exclude>tests/lib/Integration/API/SubdocumentFieldSortClauseTest.php</exclude>
             <exclude>tests/lib/Integration/API/SubdocumentQueryCriterionTest.php</exclude>
+            <exclude>tests/lib/Integration/API/FulltextSpellcheckCriterionTest.php</exclude>
             <exclude>tests/lib/Integration/Solr/RawFacetDomainTest.php</exclude>
             <exclude>tests/lib/Integration/Solr/RawFacetTest.php</exclude>
         </testsuite>

--- a/phpunit-integration-legacy.xml
+++ b/phpunit-integration-legacy.xml
@@ -17,6 +17,7 @@
             <exclude>tests/lib/Integration/API/SubdocumentFieldSortClauseTest.php</exclude>
             <exclude>tests/lib/Integration/API/SubdocumentQueryCriterionTest.php</exclude>
             <exclude>tests/lib/Integration/API/FulltextSpellcheckCriterionTest.php</exclude>
+            <exclude>tests/lib/Integration/API/ExtraFieldsTest.php</exclude>
             <exclude>tests/lib/Integration/Solr/RawFacetDomainTest.php</exclude>
             <exclude>tests/lib/Integration/Solr/RawFacetTest.php</exclude>
         </testsuite>

--- a/tests/lib/Integration/API/ExtraFieldsTest.php
+++ b/tests/lib/Integration/API/ExtraFieldsTest.php
@@ -18,7 +18,7 @@ class ExtraFieldsTest extends BaseTest
         return [
             [
                 new LocationQuery([
-                    'query' => new FullTextCriterion('comments'),
+                    'query' => new FullTextCriterion('*comments*'),
                     'filter' => new Criterion\ContentTypeIdentifier('extra_fields_test'),
                     'extraFields' => [],
                 ]),
@@ -28,10 +28,11 @@ class ExtraFieldsTest extends BaseTest
                 new LocationQuery([
                     'query' => new FullTextCriterion('comments'),
                     'filter' => new Criterion\ContentTypeIdentifier('extra_fields_test'),
-                    'extraFields' => ['extra_prefixed_name_s'],
+                    'extraFields' => ['extra_prefixed_name_s', 'extra_content_type_identifier_s'],
                 ]),
                 [
                     'extra_prefixed_name_s' => 'prefix No comments article',
+                    'extra_content_type_identifier_s' => 'extra_fields_test',
                 ],
             ],
             [
@@ -73,12 +74,13 @@ class ExtraFieldsTest extends BaseTest
                 new LocationQuery([
                     'query' => new FullTextCriterion('another'),
                     'filter' => new Criterion\ContentTypeIdentifier('extra_fields_test'),
-                    'extraFields' => ['extra_prefixed_name_s', 'extra_comment_count_i', 'extra_has_comments_b'],
+                    'extraFields' => ['extra_prefixed_name_s', 'extra_comment_count_i', 'extra_has_comments_b', 'extra_content_type_identifier_s'],
                 ]),
                 [
                     'extra_prefixed_name_s' => 'prefix Just another article',
                     'extra_comment_count_i' => 2,
                     'extra_has_comments_b' => true,
+                    'extra_content_type_identifier_s' => 'extra_fields_test',
                 ],
             ],
         ];
@@ -176,6 +178,8 @@ class ExtraFieldsTest extends BaseTest
      *
      * @param \Netgen\EzPlatformSearchExtra\API\Values\Content\Search\LocationQuery $query
      * @param array $expectedExtraFields
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
     public function testFindLocations(LocationQuery $query, array $expectedExtraFields)
     {

--- a/tests/lib/Integration/API/ExtraFieldsTest.php
+++ b/tests/lib/Integration/API/ExtraFieldsTest.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Tests\Integration\API;
+
+use eZ\Publish\API\Repository\Tests\BaseTest;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Search\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use Netgen\EzPlatformSearchExtra\Tests\API\FullTextCriterion;
+
+/**
+ * @group extra-fields
+ */
+class ExtraFieldsTest extends BaseTest
+{
+    public function providerForTestFind()
+    {
+        return [
+            [
+                new LocationQuery([
+                    'query' => new FullTextCriterion('comments'),
+                    'filter' => new Criterion\ContentTypeIdentifier('extra_fields_test'),
+                    'extraFields' => [],
+                ]),
+                [],
+            ],
+            [
+                new LocationQuery([
+                    'query' => new FullTextCriterion('comments'),
+                    'filter' => new Criterion\ContentTypeIdentifier('extra_fields_test'),
+                    'extraFields' => ['extra_prefixed_name_s'],
+                ]),
+                [
+                    'extra_prefixed_name_s' => 'prefix No comments article',
+                ],
+            ],
+            [
+                new LocationQuery([
+                    'query' => new FullTextCriterion('comments'),
+                    'filter' => new Criterion\ContentTypeIdentifier('extra_fields_test'),
+                    'extraFields' => ['extra_comment_count_i', 'extra_has_comments_b'],
+                ]),
+                [
+                    'extra_comment_count_i' => 0,
+                    'extra_has_comments_b' => false,
+                ],
+            ],
+            [
+                new LocationQuery([
+                    'query' => new FullTextCriterion('comments'),
+                    'filter' => new Criterion\ContentTypeIdentifier('extra_fields_test'),
+                    'extraFields' => ['extra_prefixed_name_s', 'extra_comment_count_i', 'extra_has_comments_b'],
+                ]),
+                [
+                    'extra_prefixed_name_s' => 'prefix No comments article',
+                    'extra_comment_count_i' => 0,
+                    'extra_has_comments_b' => false,
+                ],
+            ],
+            [
+                new LocationQuery([
+                    'query' => new FullTextCriterion('popular'),
+                    'filter' => new Criterion\ContentTypeIdentifier('extra_fields_test'),
+                    'extraFields' => ['extra_prefixed_name_s', 'extra_comment_count_i', 'extra_has_comments_b'],
+                ]),
+                [
+                    'extra_prefixed_name_s' => 'prefix Very popular article',
+                    'extra_comment_count_i' => 6,
+                    'extra_has_comments_b' => true,
+                ],
+            ],
+            [
+                new LocationQuery([
+                    'query' => new FullTextCriterion('another'),
+                    'filter' => new Criterion\ContentTypeIdentifier('extra_fields_test'),
+                    'extraFields' => ['extra_prefixed_name_s', 'extra_comment_count_i', 'extra_has_comments_b'],
+                ]),
+                [
+                    'extra_prefixed_name_s' => 'prefix Just another article',
+                    'extra_comment_count_i' => 2,
+                    'extra_has_comments_b' => true,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testPrepareTestFixtures()
+    {
+        $repository = $this->getRepository();
+        $contentService = $repository->getContentService();
+        $contentTypeService = $repository->getContentTypeService();
+        $locationService = $repository->getLocationService();
+
+        $contentTypeGroups = $contentTypeService->loadContentTypeGroups();
+        $contentTypeCreateStruct = $contentTypeService->newContentTypeCreateStruct('extra_fields_test');
+        $contentTypeCreateStruct->mainLanguageCode = 'eng-GB';
+        $contentTypeCreateStruct->names = ['eng-GB' => 'Article'];
+
+        $fieldDefinitionCreateStruct = $contentTypeService->newFieldDefinitionCreateStruct('name', 'ezstring');
+        $fieldDefinitionCreateStruct->position = 0;
+        $contentTypeCreateStruct->addFieldDefinition($fieldDefinitionCreateStruct);
+
+        $contentTypeDraft = $contentTypeService->createContentType($contentTypeCreateStruct, [reset($contentTypeGroups)]);
+        $contentTypeService->publishContentTypeDraft($contentTypeDraft);
+        $contentType = $contentTypeService->loadContentTypeByIdentifier('extra_fields_test');
+
+        $contentTypeCreateStruct = $contentTypeService->newContentTypeCreateStruct('extra_fields_test_comment');
+        $contentTypeCreateStruct->mainLanguageCode = 'eng-GB';
+        $contentTypeCreateStruct->names = ['eng-GB' => 'Comment'];
+
+        $fieldDefinitionCreateStruct = $contentTypeService->newFieldDefinitionCreateStruct('comment', 'ezstring');
+        $fieldDefinitionCreateStruct->position = 0;
+        $contentTypeCreateStruct->addFieldDefinition($fieldDefinitionCreateStruct);
+
+        $contentTypeDraft = $contentTypeService->createContentType($contentTypeCreateStruct, [reset($contentTypeGroups)]);
+        $contentTypeService->publishContentTypeDraft($contentTypeDraft);
+        $commentContentType = $contentTypeService->loadContentTypeByIdentifier('extra_fields_test_comment');
+
+        $values = [
+            'No comments article' => [],
+            'Very popular article' => ['comment 1', 'another comment', 'test comment', 'comment on comment', 'comment 2', 'test'],
+            'Just another article' => ['first comment', 'second comment'],
+        ];
+
+        $locationCreateStruct = $locationService->newLocationCreateStruct(2);
+
+        foreach ($values as $title => $comments) {
+            $contentCreateStruct = $contentService->newContentCreateStruct($contentType, 'eng-GB');
+            $contentCreateStruct->setField('name', $title);
+            $contentDraft = $contentService->createContent($contentCreateStruct, [$locationCreateStruct]);
+            $articleContent = $contentService->publishVersion($contentDraft->versionInfo);
+
+            foreach ($comments as $comment) {
+                $commentLocationCreateStruct = $locationService->newLocationCreateStruct($articleContent->contentInfo->mainLocationId);
+                $commentContentCreateStruct = $contentService->newContentCreateStruct($commentContentType, 'eng-GB');
+                $commentContentCreateStruct->setField('comment', $comment);
+                $commentContentDraft = $contentService->createContent($commentContentCreateStruct, [$commentLocationCreateStruct]);
+                $contentService->publishVersion($commentContentDraft->versionInfo);
+            }
+        }
+
+        $this->refreshSearch($repository);
+
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @dataProvider providerForTestFind
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     * @param array $expectedExtraFields
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testFindContent(Query $query, array $expectedExtraFields)
+    {
+        $searchService = $this->getSearchService(false);
+
+        /** @var \Netgen\EzPlatformSearchExtra\API\Values\Content\Search\SearchResult $searchResult */
+        $searchResult = $searchService->findContentInfo($query);
+
+        $this->assertEquals($expectedExtraFields, $searchResult->searchHits[0]->extraFields);
+    }
+
+    /**
+     * @dataProvider providerForTestFind
+     *
+     * @param \Netgen\EzPlatformSearchExtra\API\Values\Content\Search\LocationQuery $query
+     * @param array $expectedExtraFields
+     */
+    public function testFindLocations(LocationQuery $query, array $expectedExtraFields)
+    {
+        $searchService = $this->getSearchService(false);
+
+        /** @var \Netgen\EzPlatformSearchExtra\API\Values\Content\Search\SearchResult $searchResult */
+        $searchResult = $searchService->findLocations($query);
+
+        $this->assertEquals($expectedExtraFields, $searchResult->searchHits[0]->extraFields);
+    }
+
+    protected function getSearchService($initialInitializeFromScratch = true)
+    {
+        return $this->getRepository($initialInitializeFromScratch)->getSearchService();
+    }
+}

--- a/tests/lib/Integration/API/FulltextSpellcheckCriterionTest.php
+++ b/tests/lib/Integration/API/FulltextSpellcheckCriterionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Netgen\EzPlatformSearchExtra\Tests\Solr;
+namespace Netgen\EzPlatformSearchExtra\Tests\Integration\API;
 
 use eZ\Publish\API\Repository\Tests\BaseTest;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
@@ -9,6 +9,9 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use Netgen\EzPlatformSearchExtra\API\Values\Content\Search\WordSuggestion;
 use Netgen\EzPlatformSearchExtra\Tests\API\FullTextCriterion;
 
+/**
+ * @group fulltext-spellcheck
+ */
 class FulltextSpellcheckCriterionTest extends BaseTest
 {
     public function providerForTestFind()

--- a/tests/lib/Integration/Implementation/Common/Slot/TestChildUpdatesParent.php
+++ b/tests/lib/Integration/Implementation/Common/Slot/TestChildUpdatesParent.php
@@ -41,7 +41,8 @@ class TestChildUpdatesParent extends Slot
             return;
         }
 
-        $parentLocation = $this->persistenceHandler->locationHandler()->load($contentInfo->mainLocationId);
+        $location = $this->persistenceHandler->locationHandler()->load($contentInfo->mainLocationId);
+        $parentLocation = $this->persistenceHandler->locationHandler()->load($location->parentId);
         $parentContentInfo = $contentHandler->loadContentInfo($parentLocation->contentId);
         $parentContentType = $this->persistenceHandler->contentTypeHandler()->load($parentContentInfo->contentTypeId);
 

--- a/tests/lib/Integration/Implementation/Common/Slot/TestChildUpdatesParent.php
+++ b/tests/lib/Integration/Implementation/Common/Slot/TestChildUpdatesParent.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Tests\Integration\Implementation\Common\Slot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+use eZ\Publish\Core\Search\Common\Slot;
+
+class TestChildUpdatesParent extends Slot
+{
+    const PARENT_CONTENT_TYPE_IDENTIFIER = 'extra_fields_test';
+
+    const CHILD_CONTENT_TYPE_IDENTIFIER = 'extra_fields_test_comment';
+
+    /**
+     * Receive the given $signal and react on it.
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function receive(Signal $signal)
+    {
+        if (
+            !$signal instanceof Signal\ContentService\PublishVersionSignal
+            && !$signal instanceof Signal\ContentService\DeleteContentSignal
+            && !$signal instanceof Signal\LocationService\DeleteLocationSignal
+            && !$signal instanceof Signal\LocationService\HideLocationSignal
+            && !$signal instanceof Signal\LocationService\UnhideLocationSignal
+            && !$signal instanceof Signal\TrashService\TrashSignal
+            && !$signal instanceof Signal\TrashService\RecoverSignal
+        ) {
+            return;
+        }
+
+        $contentHandler = $this->persistenceHandler->contentHandler();
+        $content = $contentHandler->load($signal->contentId, $signal->versionNo);
+        $contentInfo = $content->versionInfo->contentInfo;
+        $contentType = $this->persistenceHandler->contentTypeHandler()->load($contentInfo->contentTypeId);
+
+        if ($contentType->identifier !== self::CHILD_CONTENT_TYPE_IDENTIFIER) {
+            return;
+        }
+
+        $parentLocation = $this->persistenceHandler->locationHandler()->load($contentInfo->mainLocationId);
+        $parentContentInfo = $contentHandler->loadContentInfo($parentLocation->contentId);
+        $parentContentType = $this->persistenceHandler->contentTypeHandler()->load($parentContentInfo->contentTypeId);
+
+        if ($parentContentType->identifier !== self::PARENT_CONTENT_TYPE_IDENTIFIER) {
+            return;
+        }
+
+        $this->searchHandler->indexContent(
+            $contentHandler->load($parentContentInfo->id, $parentContentInfo->currentVersionNo)
+        );
+    }
+}

--- a/tests/lib/Integration/Implementation/Solr/FieldMapper/TestContentFieldMapper.php
+++ b/tests/lib/Integration/Implementation/Solr/FieldMapper/TestContentFieldMapper.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Tests\Integration\Implementation\Solr\FieldMapper;
+
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\SPI\Persistence\Content;
+use eZ\Publish\SPI\Persistence\Content as SPIContent;
+use eZ\Publish\SPI\Persistence\Content\Field as ContentField;
+use eZ\Publish\SPI\Persistence\Content\Type as ContentType;
+use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType\BooleanField;
+use eZ\Publish\SPI\Search\FieldType\IntegerField;
+use eZ\Publish\SPI\Search\FieldType\StringField;
+use eZ\Publish\SPI\Search\Handler as SearchHandler;
+use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use RuntimeException;
+
+class TestContentFieldMapper extends ContentFieldMapper
+{
+    const CONTENT_TYPE_IDENTIFIER = 'extra_fields_test';
+
+    const CHILD_CONTENT_TYPE_IDENTIFIER = 'extra_fields_test_comment';
+
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Type\Handler
+     */
+    private $contentTypeHandler;
+
+    /**
+     * @var \eZ\Publish\SPI\Search\Handler
+     */
+    private $searchHandler;
+
+    /**
+     * TestContentFieldMapper constructor.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
+     * @param \eZ\Publish\SPI\Search\Handler $searchHandler
+     */
+    public function __construct(ContentTypeHandler $contentTypeHandler, SearchHandler $searchHandler)
+    {
+        $this->contentTypeHandler = $contentTypeHandler;
+        $this->searchHandler = $searchHandler;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function accept(SPIContent $content)
+    {
+        $contentType = $this->contentTypeHandler->load(
+            $content->versionInfo->contentInfo->contentTypeId
+        );
+
+        return $contentType->identifier === self::CONTENT_TYPE_IDENTIFIER;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mapFields(SPIContent $content)
+    {
+        $contentType = $this->contentTypeHandler->load(
+            $content->versionInfo->contentInfo->contentTypeId
+        );
+
+        $commentCount = $this->getCommentCount($content);
+
+        $prefixedName = 'prefix '.$this->extractField($content, $contentType, 'name')->value->data;
+
+        return [
+            new Field(
+                'extra_prefixed_name',
+                $prefixedName,
+                new StringField()
+            ),
+            new Field(
+                'extra_comment_count',
+                $commentCount,
+                new IntegerField()
+            ),
+            new Field(
+                'extra_has_comments',
+                $commentCount > 0,
+                new BooleanField()
+            ),
+        ];
+    }
+
+    /**
+     * @param \eZ\Publish\SPI\Persistence\Content $content
+     * @param \eZ\Publish\SPI\Persistence\Content\Type $contentType
+     * @param $identifier
+     *
+     * @return \eZ\Publish\SPI\Persistence\Content\Field
+     */
+    private function extractField(Content $content, ContentType $contentType, $identifier): ContentField
+    {
+        $fieldDefinitionId = $this->getFieldDefinitionId($contentType, $identifier);
+
+        foreach ($content->fields as $field) {
+            if ($field->fieldDefinitionId === $fieldDefinitionId) {
+                return $field;
+            }
+        }
+
+        throw new RuntimeException(
+            "Could not extract field '{$identifier}'"
+        );
+    }
+
+    /**
+     * @param \eZ\Publish\SPI\Persistence\Content\Type $contentType
+     * @param $identifier
+     *
+     * @return mixed
+     */
+    private function getFieldDefinitionId(ContentType $contentType, $identifier)
+    {
+        foreach ($contentType->fieldDefinitions as $fieldDefinition) {
+            if ($fieldDefinition->identifier === $identifier) {
+                return $fieldDefinition->id;
+            }
+        }
+
+        throw new RuntimeException(
+            "Could not extract field definition '{$identifier}'"
+        );
+    }
+
+    /**
+     * @param \eZ\Publish\SPI\Persistence\Content $content
+     *
+     * @return int
+     */
+    private function getCommentCount(Content $content)
+    {
+        $criteria = [
+            new Criterion\ParentLocationId($content->versionInfo->contentInfo->mainLocationId),
+            new Criterion\ContentTypeIdentifier(self::CHILD_CONTENT_TYPE_IDENTIFIER),
+        ];
+
+        $query = new LocationQuery();
+        $query->filter = new Criterion\LogicalAnd($criteria);
+        $query->limit = 0;
+
+        return $this->searchHandler->findLocations($query)->totalCount;
+    }
+}

--- a/tests/lib/Integration/Implementation/Solr/FieldMapper/TestContentFieldMapper.php
+++ b/tests/lib/Integration/Implementation/Solr/FieldMapper/TestContentFieldMapper.php
@@ -2,150 +2,27 @@
 
 namespace Netgen\EzPlatformSearchExtra\Tests\Integration\Implementation\Solr\FieldMapper;
 
-use eZ\Publish\API\Repository\Values\Content\LocationQuery;
-use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Persistence\Content as SPIContent;
-use eZ\Publish\SPI\Persistence\Content\Field as ContentField;
-use eZ\Publish\SPI\Persistence\Content\Type as ContentType;
-use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
-use eZ\Publish\SPI\Search\Field;
-use eZ\Publish\SPI\Search\FieldType\BooleanField;
-use eZ\Publish\SPI\Search\FieldType\IntegerField;
-use eZ\Publish\SPI\Search\FieldType\StringField;
-use eZ\Publish\SPI\Search\Handler as SearchHandler;
 use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper;
-use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use RuntimeException;
 
-class TestContentFieldMapper extends ContentFieldMapper
+class TestContentFieldMapper extends ContentFieldMapper implements TestFieldMapperInterface
 {
-    const CONTENT_TYPE_IDENTIFIER = 'extra_fields_test';
-
-    const CHILD_CONTENT_TYPE_IDENTIFIER = 'extra_fields_test_comment';
-
-    /**
-     * @var \eZ\Publish\SPI\Persistence\Content\Type\Handler
-     */
-    private $contentTypeHandler;
-
-    /**
-     * @var \eZ\Publish\SPI\Search\Handler
-     */
-    private $searchHandler;
-
-    /**
-     * TestContentFieldMapper constructor.
-     *
-     * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
-     * @param \eZ\Publish\SPI\Search\Handler $searchHandler
-     */
-    public function __construct(ContentTypeHandler $contentTypeHandler, SearchHandler $searchHandler)
-    {
-        $this->contentTypeHandler = $contentTypeHandler;
-        $this->searchHandler = $searchHandler;
-    }
+    use TestFieldMapperTrait;
 
     /**
      * {@inheritdoc}
      */
     public function accept(SPIContent $content)
     {
-        $contentType = $this->contentTypeHandler->load(
-            $content->versionInfo->contentInfo->contentTypeId
-        );
-
-        return $contentType->identifier === self::CONTENT_TYPE_IDENTIFIER;
+        return $this->accepts($content);
     }
+
 
     /**
      * {@inheritdoc}
      */
     public function mapFields(SPIContent $content)
     {
-        $contentType = $this->contentTypeHandler->load(
-            $content->versionInfo->contentInfo->contentTypeId
-        );
-
-        $commentCount = $this->getCommentCount($content);
-
-        $prefixedName = 'prefix '.$this->extractField($content, $contentType, 'name')->value->data;
-
-        return [
-            new Field(
-                'extra_prefixed_name',
-                $prefixedName,
-                new StringField()
-            ),
-            new Field(
-                'extra_comment_count',
-                $commentCount,
-                new IntegerField()
-            ),
-            new Field(
-                'extra_has_comments',
-                $commentCount > 0,
-                new BooleanField()
-            ),
-        ];
-    }
-
-    /**
-     * @param \eZ\Publish\SPI\Persistence\Content $content
-     * @param \eZ\Publish\SPI\Persistence\Content\Type $contentType
-     * @param $identifier
-     *
-     * @return \eZ\Publish\SPI\Persistence\Content\Field
-     */
-    private function extractField(Content $content, ContentType $contentType, $identifier): ContentField
-    {
-        $fieldDefinitionId = $this->getFieldDefinitionId($contentType, $identifier);
-
-        foreach ($content->fields as $field) {
-            if ($field->fieldDefinitionId === $fieldDefinitionId) {
-                return $field;
-            }
-        }
-
-        throw new RuntimeException(
-            "Could not extract field '{$identifier}'"
-        );
-    }
-
-    /**
-     * @param \eZ\Publish\SPI\Persistence\Content\Type $contentType
-     * @param $identifier
-     *
-     * @return mixed
-     */
-    private function getFieldDefinitionId(ContentType $contentType, $identifier)
-    {
-        foreach ($contentType->fieldDefinitions as $fieldDefinition) {
-            if ($fieldDefinition->identifier === $identifier) {
-                return $fieldDefinition->id;
-            }
-        }
-
-        throw new RuntimeException(
-            "Could not extract field definition '{$identifier}'"
-        );
-    }
-
-    /**
-     * @param \eZ\Publish\SPI\Persistence\Content $content
-     *
-     * @return int
-     */
-    private function getCommentCount(Content $content)
-    {
-        $criteria = [
-            new Criterion\ParentLocationId($content->versionInfo->contentInfo->mainLocationId),
-            new Criterion\ContentTypeIdentifier(self::CHILD_CONTENT_TYPE_IDENTIFIER),
-        ];
-
-        $query = new LocationQuery();
-        $query->filter = new Criterion\LogicalAnd($criteria);
-        $query->limit = 0;
-
-        return $this->searchHandler->findLocations($query)->totalCount;
+        return $this->getFields($content);
     }
 }

--- a/tests/lib/Integration/Implementation/Solr/FieldMapper/TestFieldMapperInterface.php
+++ b/tests/lib/Integration/Implementation/Solr/FieldMapper/TestFieldMapperInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Tests\Integration\Implementation\Solr\FieldMapper;
+
+interface TestFieldMapperInterface
+{
+    const CONTENT_TYPE_IDENTIFIER = 'extra_fields_test';
+
+    const CHILD_CONTENT_TYPE_IDENTIFIER = 'extra_fields_test_comment';
+}

--- a/tests/lib/Integration/Implementation/Solr/FieldMapper/TestFieldMapperTrait.php
+++ b/tests/lib/Integration/Implementation/Solr/FieldMapper/TestFieldMapperTrait.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Tests\Integration\Implementation\Solr\FieldMapper;
+
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\SPI\Persistence\Content;
+use eZ\Publish\SPI\Persistence\Content as SPIContent;
+use eZ\Publish\SPI\Persistence\Content\Type as ContentType;
+use eZ\Publish\SPI\Persistence\Content\Handler as ContentHandler;
+use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType\BooleanField;
+use eZ\Publish\SPI\Search\FieldType\IntegerField;
+use eZ\Publish\SPI\Search\FieldType\StringField;
+use eZ\Publish\SPI\Search\Handler as SearchHandler;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use RuntimeException;
+
+trait TestFieldMapperTrait
+{
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Handler
+     */
+    private $contentHandler;
+
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Type\Handler
+     */
+    private $contentTypeHandler;
+
+    /**
+     * @var \eZ\Publish\SPI\Search\Handler
+     */
+    private $searchHandler;
+
+    /**
+     * TestFieldMapperTrait constructor.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Handler $contentHandler
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
+     * @param \eZ\Publish\SPI\Search\Handler $searchHandler
+     */
+    public function __construct
+    (
+        ContentHandler $contentHandler,
+        ContentTypeHandler $contentTypeHandler,
+        SearchHandler $searchHandler
+    ) {
+        $this->contentHandler = $contentHandler;
+        $this->contentTypeHandler = $contentTypeHandler;
+        $this->searchHandler = $searchHandler;
+    }
+
+    public function accepts(SPIContent $content)
+    {
+        $contentType = $this->contentTypeHandler->load(
+            $content->versionInfo->contentInfo->contentTypeId
+        );
+
+        return $contentType->identifier === self::CONTENT_TYPE_IDENTIFIER;
+    }
+
+    public function getFields(SPIContent $content)
+    {
+        $contentType = $this->contentTypeHandler->load(
+            $content->versionInfo->contentInfo->contentTypeId
+        );
+
+        $commentCount = $this->getCommentCount($content);
+
+        $prefixedName = 'prefix '.$this->extractField($content, $contentType, 'name')->value->data;
+
+        return [
+            new Field(
+                'extra_prefixed_name',
+                $prefixedName,
+                new StringField()
+            ),
+            new Field(
+                'extra_comment_count',
+                $commentCount,
+                new IntegerField()
+            ),
+            new Field(
+                'extra_has_comments',
+                $commentCount > 0,
+                new BooleanField()
+            ),
+            new Field(
+                'extra_content_type_identifier',
+                $contentType->identifier,
+                new StringField()
+            ),
+        ];
+    }
+
+    /**
+     * @param \eZ\Publish\SPI\Persistence\Content $content
+     * @param \eZ\Publish\SPI\Persistence\Content\Type $contentType
+     * @param $identifier
+     *
+     * @return \eZ\Publish\SPI\Persistence\Content\Field
+     */
+    private function extractField(Content $content, ContentType $contentType, $identifier)
+    {
+        $fieldDefinitionId = $this->getFieldDefinitionId($contentType, $identifier);
+
+        foreach ($content->fields as $field) {
+            if ($field->fieldDefinitionId === $fieldDefinitionId) {
+                return $field;
+            }
+        }
+
+        throw new RuntimeException(
+            "Could not extract field '{$identifier}'"
+        );
+    }
+
+    /**
+     * @param \eZ\Publish\SPI\Persistence\Content\Type $contentType
+     * @param $identifier
+     *
+     * @return mixed
+     */
+    private function getFieldDefinitionId(ContentType $contentType, $identifier)
+    {
+        foreach ($contentType->fieldDefinitions as $fieldDefinition) {
+            if ($fieldDefinition->identifier === $identifier) {
+                return $fieldDefinition->id;
+            }
+        }
+
+        throw new RuntimeException(
+            "Could not extract field definition '{$identifier}'"
+        );
+    }
+
+    /**
+     * @param \eZ\Publish\SPI\Persistence\Content $content
+     *
+     * @return int
+     */
+    private function getCommentCount(Content $content)
+    {
+        $criteria = [
+            new Criterion\ParentLocationId($content->versionInfo->contentInfo->mainLocationId),
+            new Criterion\ContentTypeIdentifier(self::CHILD_CONTENT_TYPE_IDENTIFIER),
+        ];
+
+        $query = new LocationQuery();
+        $query->filter = new Criterion\LogicalAnd($criteria);
+        $query->limit = 0;
+
+        return $this->searchHandler->findLocations($query)->totalCount;
+    }
+}

--- a/tests/lib/Integration/Implementation/Solr/FieldMapper/TestLocationFieldMapper.php
+++ b/tests/lib/Integration/Implementation/Solr/FieldMapper/TestLocationFieldMapper.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Netgen\EzPlatformSearchExtra\Tests\Integration\Implementation\Solr\FieldMapper;
+
+use eZ\Publish\SPI\Persistence\Content\Location as SPILocation;
+use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper;
+
+class TestLocationFieldMapper extends LocationFieldMapper implements TestFieldMapperInterface
+{
+    use TestFieldMapperTrait;
+
+    /**
+     * @param \eZ\Publish\SPI\Persistence\Content\Location $location
+     *
+     * @return bool
+     */
+    public function accept(SPILocation $location)
+    {
+        $content = $this->contentHandler->load($location->contentId);
+
+        return $this->accepts($content);
+    }
+
+    /**
+     * @param \eZ\Publish\SPI\Persistence\Content\Location $location
+     *
+     * @return \eZ\Publish\SPI\Search\Field[]|void
+     */
+    public function mapFields(SPILocation $location)
+    {
+        $content = $this->contentHandler->load($location->contentId);
+
+        return $this->getFields($content);
+    }
+}

--- a/tests/lib/Integration/Resources/config/services.yml
+++ b/tests/lib/Integration/Resources/config/services.yml
@@ -20,6 +20,12 @@ services:
         tags:
             - {name: ezpublish.search.solr.slot, signal: ContentService\PublishVersionSignal}
 
+    netgen_test.search.solr.slot.child_updates_parent:
+        parent: ezpublish.search.solr.slot
+        class: Netgen\EzPlatformSearchExtra\Tests\Integration\Implementation\Common\Slot\TestChildUpdatesParent
+        tags:
+            - {name: ezpublish.search.solr.slot, signal: ContentService\PublishVersionSignal}
+
     netgen_test.search.solr.field_mapper.content:
         class: Netgen\EzPlatformSearchExtra\Tests\Integration\Implementation\Solr\FieldMapper\TestContentFieldMapper
         arguments:

--- a/tests/lib/Integration/Resources/config/services.yml
+++ b/tests/lib/Integration/Resources/config/services.yml
@@ -19,3 +19,11 @@ services:
         class: '%ezpublish.search.solr.slot.publish_version.class%'
         tags:
             - {name: ezpublish.search.solr.slot, signal: ContentService\PublishVersionSignal}
+
+    netgen_test.search.solr.field_mapper.content:
+        class: Netgen\EzPlatformSearchExtra\Tests\Integration\Implementation\Solr\FieldMapper\TestContentFieldMapper
+        arguments:
+            - '@ezpublish.spi.persistence.content_type_handler'
+            - '@ezpublish.spi.search.legacy'
+        tags:
+            - {name: ezpublish.search.solr.field_mapper.content}

--- a/tests/lib/Integration/Resources/config/services.yml
+++ b/tests/lib/Integration/Resources/config/services.yml
@@ -29,7 +29,17 @@ services:
     netgen_test.search.solr.field_mapper.content:
         class: Netgen\EzPlatformSearchExtra\Tests\Integration\Implementation\Solr\FieldMapper\TestContentFieldMapper
         arguments:
+            - '@ezpublish.spi.persistence.content_handler'
             - '@ezpublish.spi.persistence.content_type_handler'
             - '@ezpublish.spi.search.legacy'
         tags:
             - {name: ezpublish.search.solr.field_mapper.content}
+
+    netgen_test.search.solr.field_mapper.location:
+        class: Netgen\EzPlatformSearchExtra\Tests\Integration\Implementation\Solr\FieldMapper\TestLocationFieldMapper
+        arguments:
+            - '@ezpublish.spi.persistence.content_handler'
+            - '@ezpublish.spi.persistence.content_type_handler'
+            - '@ezpublish.spi.search.legacy'
+        tags:
+            - { name: ezpublish.search.solr.field_mapper.location }

--- a/tests/lib/Kernel/SearchServiceLocationTest.php
+++ b/tests/lib/Kernel/SearchServiceLocationTest.php
@@ -5,6 +5,8 @@ namespace Netgen\EzPlatformSearchExtra\Tests\Kernel;
 use eZ\Publish\API\Repository\Tests\SearchServiceLocationTest as KernelSearchServiceLocationTest;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult as KernelSearchResult;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchHit as KernelSearchHit;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Search\SearchHit;
 use Netgen\EzPlatformSearchExtra\API\Values\Content\Search\SearchResult;
 
 class SearchServiceLocationTest extends KernelSearchServiceLocationTest
@@ -34,14 +36,32 @@ class SearchServiceLocationTest extends KernelSearchServiceLocationTest
 
     private function mapToKernelSearchResult(SearchResult $data)
     {
+        $kernelSearchHits = [];
+
+        /** @var \Netgen\EzPlatformSearchExtra\API\Values\Content\Search\SearchHit $searchHit */
+        foreach ($data->searchHits as $searchHit) {
+            $kernelSearchHits[] = $this->mapToKernelSearchHit($searchHit);
+        }
+
         return new KernelSearchResult([
             'facets' => $data->facets,
-            'searchHits' => $data->searchHits,
+            'searchHits' => $kernelSearchHits,
             'spellSuggestion' => $data->spellSuggestion,
             'time' => $data->time,
             'timedOut' => $data->timedOut,
             'maxScore' => $data->maxScore,
             'totalCount' => $data->totalCount,
+        ]);
+    }
+
+    private function mapToKernelSearchHit(SearchHit $searchHit)
+    {
+        return new KernelSearchHit([
+            'valueObject' => $searchHit->valueObject,
+            'score' => $searchHit->score,
+            'index' => $searchHit->index,
+            'matchedTranslation' => $searchHit->matchedTranslation,
+            'highlight' => $searchHit->highlight,
         ]);
     }
 }

--- a/tests/lib/Kernel/SearchServiceTest.php
+++ b/tests/lib/Kernel/SearchServiceTest.php
@@ -5,6 +5,8 @@ namespace Netgen\EzPlatformSearchExtra\Tests\Kernel;
 use eZ\Publish\API\Repository\Tests\SearchServiceTest as KernelSearchServiceTest;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult as KernelSearchResult;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchHit as KernelSearchHit;
+use Netgen\EzPlatformSearchExtra\API\Values\Content\Search\SearchHit;
 use Netgen\EzPlatformSearchExtra\API\Values\Content\Search\SearchResult;
 
 class SearchServiceTest extends KernelSearchServiceTest
@@ -32,14 +34,32 @@ class SearchServiceTest extends KernelSearchServiceTest
 
     private function mapToKernelSearchResult(SearchResult $data): KernelSearchResult
     {
+        $kernelSearchHits = [];
+
+        /** @var \Netgen\EzPlatformSearchExtra\API\Values\Content\Search\SearchHit $searchHit */
+        foreach ($data->searchHits as $searchHit) {
+            $kernelSearchHits[] = $this->mapToKernelSearchHit($searchHit);
+        }
+
         return new KernelSearchResult([
             'facets' => $data->facets,
-            'searchHits' => $data->searchHits,
+            'searchHits' => $kernelSearchHits,
             'spellSuggestion' => $data->spellSuggestion,
             'time' => $data->time,
             'timedOut' => $data->timedOut,
             'maxScore' => $data->maxScore,
             'totalCount' => $data->totalCount,
+        ]);
+    }
+
+    private function mapToKernelSearchHit(SearchHit $searchHit): KernelSearchHit
+    {
+        return new KernelSearchHit([
+            'valueObject' => $searchHit->valueObject,
+            'score' => $searchHit->score,
+            'index' => $searchHit->index,
+            'matchedTranslation' => $searchHit->matchedTranslation,
+            'highlight' => $searchHit->highlight,
         ]);
     }
 }


### PR DESCRIPTION
Currently it's not possible to fetch additional Solr fields during content search (eg. if we indexed some additional data with the document field mapper). With this PR, we can use our overridden query and provide the list of extra fields that we want to extract from Solr documents. Those fields, if exist, will appear in our overridden SearchHit.